### PR TITLE
Alter Sql Mode to allow zero dates for 1454 update

### DIFF
--- a/updates/1454_z2685_01_mangos_event_linkedto.sql
+++ b/updates/1454_z2685_01_mangos_event_linkedto.sql
@@ -1,3 +1,7 @@
 ALTER TABLE db_version CHANGE COLUMN required_z2684_01_mangos_creature_template required_z2685_01_mangos_event_linkedto BIT(1) NULL DEFAULT NULL;
 
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+
 ALTER TABLE game_event ADD COLUMN linkedTo mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'This event starts only if defined LinkedTo event is started' AFTER holiday;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;


### PR DESCRIPTION
The script alters the table 'game_event', which has two
columns start_time and end_time with default values
0000-00-00 00:00:00 which is disallowed in strict mode.

Fixes: #15 