### PR TITLE
update values and change defaults before altering table

### DIFF
--- a/Updates/1454_z2685_01_mangos_event_linkedto.sql
+++ b/Updates/1454_z2685_01_mangos_event_linkedto.sql
@@ -1,3 +1,7 @@
 ALTER TABLE db_version CHANGE COLUMN required_z2684_01_mangos_creature_template required_z2685_01_mangos_event_linkedto BIT(1) NULL DEFAULT NULL;
 
+UPDATE game_event SET start_time = '1970-01-01 00:00:01', end_time = '1970-01-01 00:00:01' WHERE entry IN (13, 17, 22);
+
+ALTER TABLE game_event MODIFY start_time DATETIME NOT NULL DEFAULT '1970-01-01 00:00:00' COMMENT 'Absolute start date, the event will never start before', MODIFY end_time DATETIME NOT NULL DEFAULT '1970-01-01 00:00:00' COMMENT 'Absolute end date, the event will never start after';
+
 ALTER TABLE game_event ADD COLUMN linkedTo mediumint(8) unsigned NOT NULL DEFAULT '0' COMMENT 'This event starts only if defined LinkedTo event is started' AFTER holiday;

--- a/Updates/1530_z2690_01_mangos_game_event.sql
+++ b/Updates/1530_z2690_01_mangos_game_event.sql
@@ -1,6 +1,3 @@
 ALTER TABLE db_version CHANGE COLUMN required_z2689_01_mangos_item_extraflags required_z2690_01_mangos_game_event bit;
 
 ALTER TABLE game_event MODIFY start_time DATETIME NOT NULL DEFAULT '1970-01-01 00:00:00' COMMENT 'Absolute start date, the event will never start before', MODIFY end_time DATETIME NOT NULL DEFAULT '1970-01-01 00:00:00' COMMENT 'Absolute end date, the event will never start after';
-
-UPDATE game_event SET start_time='1970-01-01 00:00:00' WHERE start_time='0000-00-00 00:00:00';
-UPDATE game_event SET end_time='1970-01-01 00:00:00' WHERE end_time='0000-00-00 00:00:00';


### PR DESCRIPTION
mysql complains about the start_time field when adding the linkedTo column; we need to fix the 'bad' values and update the defaults before adding the column.