### PR TITLE
Made quest 'Army of the Black Dragon' and 'Identifying the Brood' elite

### DIFF
--- a/Updates/1562_dustwallow_quest.sql
+++ b/Updates/1562_dustwallow_quest.sql
@@ -1,0 +1,2 @@
+-- Made quest 'Army of the Black Dragon' and 'Identifying the Brood' elite
+UPDATE quest_template SET Type = 1 WHERE entry IN (1168, 1169);


### PR DESCRIPTION
These were turned to non-elite in a later patch I believe.
I am not 100% sure about 'Identifying the Brood', because it is possible to make it with only killing Searing Hatchlings (which are not elite).