### PR TITLE
[1637] Change static name "Mac" to dynamic

### DIFF
--- a/Updates/1637_dynamic_name_on_a_quest.sql
+++ b/Updates/1637_dynamic_name_on_a_quest.sql
@@ -1,0 +1,3 @@
+-- The name Mac was hard-coded, changed to $N
+-- Changed "...may come.$B$BMac, as promised..." to "...may come.$B$B$N, as promised..."
+UPDATE `quest_template` SET `OfferRewardText` = 'Great Spirit Totem! This is dire news indeed. I must begin to plan for whatever may come.$B$B$N, as promised, here is your reward for your brave service.$B$B' WHERE `entry` = '5064' LIMIT 1;


### PR DESCRIPTION
The quest reward text was saying "Mac" instead of the character name. Reported and fixed in Elysium core.

**Before:**
Great Spirit Totem! This is dire news indeed. I must begin to plan for whatever may come.$B$BMac, as promised, here is your reward for your brave service.$B$B

**After:**
Great Spirit Totem! This is dire news indeed. I must begin to plan for whatever may come.$B$B$N, as promised, here is your reward for your brave service.$B$B

**Links:**
[Elysium pull request](https://github.com/elysium-project/server/pull/209)
[Print screen](https://www.dropbox.com/s/7enjg6h4yddlbcy/elysium_bug_wrong_name.jpg?dl=0)
[Wowhead for how it is on retail](http://www.wowhead.com/quest=5064/grimtotem-spying)
[Elysium bug tracker](https://elysium-project.org/bugtracker/issue/577)

I have no proof of how it was in vanilla, but it seems pretty obvious to me.