### PR TITLE
Create 1853_AndorhalTowersRange.sql

### DIFF
--- a/Updates/1853_AndorhalTowersRange.sql
+++ b/Updates/1853_AndorhalTowersRange.sql
@@ -1,0 +1,12 @@
+-- The range of spell 17016 does not match the range of the focused game objects, leading to a possibility of casting the spell without kill credit.
+UPDATE
+	`gameobject_template`
+SET
+	`data1` = 5
+WHERE
+	`entry` IN (
+		176094,
+		176095,
+		176096,
+		176097
+	);


### PR DESCRIPTION
The range of spell 17016 does not match the range of the focused game objects, leading to a possibility of casting the spell without kill credit.