### PR TITLE
Create 1860_MissingLockId.sql

### DIFF
--- a/Updates/1860_MissingLockId.sql
+++ b/Updates/1860_MissingLockId.sql
@@ -1,0 +1,16 @@
+-- Require mining for Ooze Covered Iron Deposit, currently not spawned anywhere.
+UPDATE
+	`gameobject_template`
+SET
+	`data0` = 41
+WHERE
+	`entry` = 73939;
+
+
+-- Require mining for Truesilver Deposit, currently not spawned anywhere.
+UPDATE
+	`gameobject_template`
+SET
+	`data0` = 380
+WHERE
+	`entry` = 181108;


### PR DESCRIPTION
Require mining for Ooze Covered Iron Deposit, currently not spawned anywhere.
Require mining for Truesilver Deposit, currently not spawned anywhere.