### PR TITLE
Create 1862_LargeTermiteMoundPosition.sql

### DIFF
--- a/Updates/1862_LargeTermiteMoundPosition.sql
+++ b/Updates/1862_LargeTermiteMoundPosition.sql
@@ -1,0 +1,7 @@
+-- The Large Termite Mound in Eastern Plaguelands is floating. This lowers its position. Unsniffed.
+UPDATE
+	`gameobject`
+SET
+	`position_z` = 145.665 -- was 147.665
+WHERE
+	`guid` = 45874


### PR DESCRIPTION
The Large Termite Mound in Eastern Plaguelands is floating. This lowers its position. Unsniffed.