### PR TITLE
Update to FORCE_WAIT and WAIT in InstallFullDB.config file

### DIFF
--- a/InstallFullDB.sh
+++ b/InstallFullDB.sh
@@ -68,6 +68,9 @@ CORE_PATH=""
 ## Define your mysql programm if this differs
 MYSQL="mysql"
 
+## Define if you want to wait a bit before applying the full database
+FORCE_WAIT="YES"
+
 ## Define if the 'dev' directory for processing development SQL files needs to be used
 ##   Set the variable to "YES" to use the dev directory
 DEV_UPDATES="NO"
@@ -109,7 +112,7 @@ then
   echo "Please bring your repositories up-to-date!"
   echo "Press CTRL+C to exit"
   # show a mini progress bar
-  for i in {1..19}
+  for i in $(seq 1 10);
   do
    echo -ne .
    sleep 1


### PR DESCRIPTION
InstallFullDB.sh now writes the $FORCE_WAIT var into the InstallFullDB.config file. This was not done before and thus the waiting could not be configured.

Also a $WAIT var is used to set the waiting time, like in tbc-db

Default wait time set to 10 seconds.
