### PR TITLE
Love is in the Air Revamp

### DIFF
--- a/Updates/Bluffwatchers.sql
+++ b/Updates/Bluffwatchers.sql
@@ -23,6 +23,39 @@ INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipmen
 INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24695, 0, 0, 0, 27654, 0, 8);
 INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24690, 0, 0, 0, 27654, 0, 8);
 
+-- Adding Gossip Menu Text for Tauren default valentine gossip
+INSERT INTO `npc_text` (`ID`, `text0_0`, `text0_1`, `lang0`, `prob0`, `em0_0`, `em0_1`, `em0_2`, `em0_3`, `em0_4`, `em0_5`, `text1_0`, `text1_1`, `lang1`, `prob1`, `em1_0`, `em1_1`, `em1_2`, `em1_3`, `em1_4`, `em1_5`, `text2_0`, `text2_1`, `lang2`, `prob2`, `em2_0`, `em2_1`, `em2_2`, `em2_3`, `em2_4`, `em2_5`, `text3_0`, `text3_1`, `lang3`, `prob3`, `em3_0`, `em3_1`, `em3_2`, `em3_3`, `em3_4`, `em3_5`, `text4_0`, `text4_1`, `lang4`, `prob4`, `em4_0`, `em4_1`, `em4_2`, `em4_3`, `em4_4`, `em4_5`, `text5_0`, `text5_1`, `lang5`, `prob5`, `em5_0`, `em5_1`, `em5_2`, `em5_3`, `em5_4`, `em5_5`, `text6_0`, `text6_1`, `lang6`, `prob6`, `em6_0`, `em6_1`, `em6_2`, `em6_3`, `em6_4`, `em6_5`, `text7_0`, `text7_1`, `lang7`, `prob7`, `em7_0`, `em7_1`, `em7_2`, `em7_3`, `em7_4`, `em7_5`) VALUES (8309, 'It seems like love is drifting on the wind. I hope that I won\'t be left out.', 'It seems like love is drifting on the wind. I hope that I won\'t be left out.', 0, 1, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0);
+
+-- Changing standard gossip to display only outside of event
+UPDATE `gossip_menu` SET `condition_id`= 501 WHERE `entry`= 721 and `text_id`= 1272;
+
+-- Love Tokens (Normal Valentine Gossip)
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (721, 8309, 0, 507);
+
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (721, 11, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 72101, 0, 0, NULL, 538);
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (721, 12, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 72101, 0, 0, NULL, 539);
+
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (721, 8282, 0, 508);
+
+-- No Cologne gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (721, 8287, 0, 541);
+
+-- No Perfume gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (721, 8289, 0, 542);
+
+-- Cast Valentine(26923) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (72101, 0, 15, 26923, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Bluffwatcher on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (72101, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (721, 8296, 0, 518);
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (721, 8291, 0, 524);
+
+
 -- Hunters
 INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24782, 0, 0, 0, 27654, 0, 8); -- Sagewind
 INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24785, 0, 0, 0, 27654, 0, 8); -- Ragetotem
@@ -60,40 +93,6 @@ UPDATE `creature_template` SET `GossipMenuId`= 12867 WHERE `Entry`= 14441;
 INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 14442, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Thunderhorn');
 INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 14442, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Thunderhorn');
 UPDATE `creature_template` SET `GossipMenuId`= 12867 WHERE `Entry`= 14442;
-
-
-
--- Changing standard gossip to display only outside of event
-UPDATE `gossip_menu` SET `condition_id`= 501 WHERE `entry`= 721 and `text_id`= 1272;
-
--- Love Tokens (Normal Valentine Gossip)
-INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (721, 8254, 0, 507);
-
--- Adding token menu option
-INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (721, 11, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 72101, 0, 0, NULL, 538);
-INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (721, 12, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 72101, 0, 0, NULL, 539);
-
--- Heartbroken gossip
-INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (721, 8282, 0, 508);
-
--- No Cologne gossip
-INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (721, 8287, 0, 541);
-
--- No Perfume gossip
-INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (721, 8289, 0, 542);
-
--- Cast Valentine(26923) in response to receiving love token
-INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (72101, 0, 15, 26923, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Bluffwatcher on player');
-INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (72101, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
-
--- Already Adored Gossip
-INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (721, 8296, 0, 518);
-
--- No Token Gossip
-INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (721, 8291, 0, 524);
-
-
-
 
 /*
 -- Honor Guard (not implemented)

--- a/Updates/Bluffwatchers.sql
+++ b/Updates/Bluffwatchers.sql
@@ -1,0 +1,106 @@
+-- Adding Love is in the Air Aura
+
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24699, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24702, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24689, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24706, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24693, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24697, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24688, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24700, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24705, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24685, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24703, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24694, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24696, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24701, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24687, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24704, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24692, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24686, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24698, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24691, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24695, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24690, 0, 0, 0, 27654, 0, 8);
+
+-- Hunters
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24782, 0, 0, 0, 27654, 0, 8); -- Sagewind
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24785, 0, 0, 0, 27654, 0, 8); -- Ragetotem
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24786, 0, 0, 0, 27654, 0, 8); -- Thunderhorn
+
+-- TB Hunter template - Gossip Menu + Options
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12867, 8254, 0, 507);
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12867, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 1286701, 0, 0, NULL, 523);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12867, 8283, 0, 508);
+-- No Perfume gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12867, 8289, 0, 520);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12867, 8296, 0, 518);
+-- Cast Valentine(26923) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1286701, 0, 15, 26923, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Bluffwatcher on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1286701, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12867, 8291, 0, 524);
+
+-- Adding Gossip options to turn on during event and off after
+-- Hunter Sagewind
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 14440, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Sagewind');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 14440, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Sagewind');
+UPDATE `creature_template` SET `GossipMenuId`= 12867 WHERE `Entry`= 14440;
+
+-- Hunter Ragetotem
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 14441, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Ragetotem');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 14441, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Ragetotem');
+UPDATE `creature_template` SET `GossipMenuId`= 12867 WHERE `Entry`= 14441;
+-- Hunter Thunderhorn
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 14442, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Thunderhorn');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 14442, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Thunderhorn');
+UPDATE `creature_template` SET `GossipMenuId`= 12867 WHERE `Entry`= 14442;
+
+/* Handled in SD2
+
+-- Changing standard gossip to display only outside of event
+UPDATE `gossip_menu` SET `condition_id`= 501 WHERE `entry`= 721 and `text_id`= 1272;
+
+-- Love Tokens (Normal Valentine Gossip)
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (721, 8254, 0, 507);
+
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (721, 11, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 0, 0, 0, NULL, 528);
+
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (721, 8282, 0, 508);
+
+-- Adding perfume + cologne npc text (Need to change this when gender check in place)
+INSERT INTO `npc_text` (`ID`, `text0_0`, `text0_1`, `lang0`, `prob0`, `em0_0`, `em0_1`, `em0_2`, `em0_3`, `em0_4`, `em0_5`, `text1_0`, `text1_1`, `lang1`, `prob1`, `em1_0`, `em1_1`, `em1_2`, `em1_3`, `em1_4`, `em1_5`, `text2_0`, `text2_1`, `lang2`, `prob2`, `em2_0`, `em2_1`, `em2_2`, `em2_3`, `em2_4`, `em2_5`, `text3_0`, `text3_1`, `lang3`, `prob3`, `em3_0`, `em3_1`, `em3_2`, `em3_3`, `em3_4`, `em3_5`, `text4_0`, `text4_1`, `lang4`, `prob4`, `em4_0`, `em4_1`, `em4_2`, `em4_3`, `em4_4`, `em4_5`, `text5_0`, `text5_1`, `lang5`, `prob5`, `em5_0`, `em5_1`, `em5_2`, `em5_3`, `em5_4`, `em5_5`, `text6_0`, `text6_1`, `lang6`, `prob6`, `em6_0`, `em6_1`, `em6_2`, `em6_3`, `em6_4`, `em6_5`, `text7_0`, `text7_1`, `lang7`, `prob7`, `em7_0`, `em7_1`, `em7_2`, `em7_3`, `em7_4`, `em7_5`) VALUES (721, 'I\'d talk to you if you smelled better. How about cologne? Maybe perfume? ', 'I\'d talk to you if you smelled better. How about cologne? Maybe perfume? ', 0, 1, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0);
+
+-- No Perfume or Cologne gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (721, 8303, 0, 530);
+
+-- Cast Valentine(26924) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (72101, 0, 15, 26923, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Bluffwatcher on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (72101, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (721, 8296, 0, 518);
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (721, 8291, 0, 524);
+
+UPDATE `gossip_menu_option` SET `action_script_id`= 72101 WHERE `menu_id`= 721 AND `id`= 11;
+
+
+
+
+-- Honor Guard (not implemented)
+
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24682, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24679, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24681, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24680, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24683, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24684, 0, 0, 0, 27654, 0, 8); */

--- a/Updates/Bluffwatchers.sql
+++ b/Updates/Bluffwatchers.sql
@@ -61,7 +61,7 @@ INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalon
 INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 14442, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Thunderhorn');
 UPDATE `creature_template` SET `GossipMenuId`= 12867 WHERE `Entry`= 14442;
 
-/* Handled in SD2
+
 
 -- Changing standard gossip to display only outside of event
 UPDATE `gossip_menu` SET `condition_id`= 501 WHERE `entry`= 721 and `text_id`= 1272;
@@ -70,18 +70,19 @@ UPDATE `gossip_menu` SET `condition_id`= 501 WHERE `entry`= 721 and `text_id`= 1
 INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (721, 8254, 0, 507);
 
 -- Adding token menu option
-INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (721, 11, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 0, 0, 0, NULL, 528);
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (721, 11, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 72101, 0, 0, NULL, 538);
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (721, 12, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 72101, 0, 0, NULL, 539);
 
 -- Heartbroken gossip
 INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (721, 8282, 0, 508);
 
--- Adding perfume + cologne npc text (Need to change this when gender check in place)
-INSERT INTO `npc_text` (`ID`, `text0_0`, `text0_1`, `lang0`, `prob0`, `em0_0`, `em0_1`, `em0_2`, `em0_3`, `em0_4`, `em0_5`, `text1_0`, `text1_1`, `lang1`, `prob1`, `em1_0`, `em1_1`, `em1_2`, `em1_3`, `em1_4`, `em1_5`, `text2_0`, `text2_1`, `lang2`, `prob2`, `em2_0`, `em2_1`, `em2_2`, `em2_3`, `em2_4`, `em2_5`, `text3_0`, `text3_1`, `lang3`, `prob3`, `em3_0`, `em3_1`, `em3_2`, `em3_3`, `em3_4`, `em3_5`, `text4_0`, `text4_1`, `lang4`, `prob4`, `em4_0`, `em4_1`, `em4_2`, `em4_3`, `em4_4`, `em4_5`, `text5_0`, `text5_1`, `lang5`, `prob5`, `em5_0`, `em5_1`, `em5_2`, `em5_3`, `em5_4`, `em5_5`, `text6_0`, `text6_1`, `lang6`, `prob6`, `em6_0`, `em6_1`, `em6_2`, `em6_3`, `em6_4`, `em6_5`, `text7_0`, `text7_1`, `lang7`, `prob7`, `em7_0`, `em7_1`, `em7_2`, `em7_3`, `em7_4`, `em7_5`) VALUES (721, 'I\'d talk to you if you smelled better. How about cologne? Maybe perfume? ', 'I\'d talk to you if you smelled better. How about cologne? Maybe perfume? ', 0, 1, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0);
+-- No Cologne gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (721, 8287, 0, 541);
 
--- No Perfume or Cologne gossip
-INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (721, 8303, 0, 530);
+-- No Perfume gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (721, 8289, 0, 542);
 
--- Cast Valentine(26924) in response to receiving love token
+-- Cast Valentine(26923) in response to receiving love token
 INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (72101, 0, 15, 26923, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Bluffwatcher on player');
 INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (72101, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
 
@@ -91,11 +92,10 @@ INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALU
 -- No Token Gossip
 INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (721, 8291, 0, 524);
 
-UPDATE `gossip_menu_option` SET `action_script_id`= 72101 WHERE `menu_id`= 721 AND `id`= 11;
 
 
 
-
+/*
 -- Honor Guard (not implemented)
 
 INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24682, 0, 0, 0, 27654, 0, 8);

--- a/Updates/Bracelets.sql
+++ b/Updates/Bracelets.sql
@@ -1,0 +1,7 @@
+-- Bracelets
+
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (26899, 0, 15, 26921, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast Create Bracelet on target');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (26899, 0, 14, 26898, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Heartbroken on target');
+
+-- Silver Shafted Arrow
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27662, 0, 15, 27570, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast Summon Peddlefeet on target');

--- a/Updates/Civilian Gossip Templates.sql
+++ b/Updates/Civilian Gossip Templates.sql
@@ -353,7 +353,7 @@ INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALU
 -- Tauren Civilian Female template - Gossip Menu + Options 
 
 -- Love Tokens
-INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12856, 8254, 0, 507);
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12856, 8309, 0, 507);
 -- Adding vendor + token menu option (Vendor options will not show on non-vendor npcs)
 INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12856, 0, 1, 'I want to browse your goods.', 3, 4, 0, 0, 0, 0, 0, NULL, 500);
 INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12856, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 1285601, 0, 0, NULL, 517);
@@ -372,7 +372,7 @@ INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALU
 
 -- Tauren Civilian Male template - Gossip Menu + Options 
 -- Love Tokens
-INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12857, 8254, 0, 507);
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12857, 8309, 0, 507);
 -- Adding vendor + token menu option (Vendor options will not show on non-vendor npcs)
 INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12857, 0, 1, 'I want to browse your goods.', 3, 4, 0, 0, 0, 0, 0, NULL, 500);
 INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12857, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 1285701, 0, 0, NULL, 523);
@@ -487,9 +487,9 @@ INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalo
 -- No Token Gossip
 INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12863, 8291, 0, 524);
 
--- Generic Horde Civilian Female template - Gossip Menu + Options
+-- Troll Civilian Female template - Gossip Menu + Options
 -- Love Tokens
-INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12872, 8245, 0, 507);
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12872, 8310, 0, 507);
 -- Adding token menu option
 INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12872, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 1287201, 0, 0, NULL, 517);
 -- Heartbroken gossip
@@ -505,9 +505,9 @@ INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalo
 -- No Token Gossip
 INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12872, 8291, 0, 524);
 
--- Generic Horde Civilian Male template - Gossip Menu + Options
+-- Troll Civilian Male template - Gossip Menu + Options
 -- Love Tokens
-INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12873, 8245, 0, 507);
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12873, 8310, 0, 507);
 -- Adding token menu option
 INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12873, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 1287301, 0, 0, NULL, 523);
 -- Heartbroken gossip
@@ -522,4 +522,40 @@ INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalo
 
 -- No Token Gossip
 INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12873, 8291, 0, 524);
+
+-- Goblin Civilian Female template - Gossip Menu + Options
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12874, 8311, 0, 507);
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12874, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 1287401, 0, 0, NULL, 517);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12874, 8283, 0, 508);
+-- No Perfume gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12874, 8287, 0, 520);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12874, 8296, 0, 518);
+-- Cast Valentine(27550) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1287401, 0, 15, 27549, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Horde Civilian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1287401, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12874, 8291, 0, 524);
+
+-- Goblin Civilian Male template - Gossip Menu + Options
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12875, 8311, 0, 507);
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12875, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 1287501, 0, 0, NULL, 523);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12875, 8283, 0, 508);
+-- No Perfume gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12875, 8289, 0, 520);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12875, 8296, 0, 518);
+-- Cast Valentine(27550) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1287501, 0, 15, 27549, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Horde Civilian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1287501, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12875, 8291, 0, 524);
 

--- a/Updates/Civilian Gossip Templates.sql
+++ b/Updates/Civilian Gossip Templates.sql
@@ -1,0 +1,525 @@
+-- Gossip Menus 12850- free for use
+
+
+-- Alliance Dwarf Civilian Female template - Gossip Menu + Options 
+
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12850, 8251, 0, 507);
+-- Adding vendor + token menu option (Vendor options will not show on non-vendor npcs)
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12850, 0, 1, 'I want to browse your goods.', 3, 4, 0, 0, 0, 0, 0, NULL, 500);
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12850, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 1285001, 0, 0, NULL, 517);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12850, 8283, 0, 508);
+-- No Cologne gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12850, 8287, 0, 519);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12850, 8296, 0, 518);
+-- Cast Valentine(27550) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1285001, 0, 15, 27550, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Alliance Civilian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1285001, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12850, 8291, 0, 524);
+
+-- Alliance Dwarf Civilian Male template - Gossip Menu + Options 
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12851, 8251, 0, 507);
+-- Adding vendor + token menu option (Vendor options will not show on non-vendor npcs)
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12851, 0, 1, 'I want to browse your goods.', 3, 4, 0, 0, 0, 0, 0, NULL, 500);
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12851, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 1285101, 0, 0, NULL, 523);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12851, 8283, 0, 508);
+-- No Perfume gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12851, 8289, 0, 520);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12851, 8296, 0, 518);
+-- Cast Valentine(27550) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1285101, 0, 15, 27550, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Alliance Civilian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1285101, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12851, 8291, 0, 524);
+
+-- Alliance Nightelf Civilian Female template - Gossip Menu + Options
+
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12852, 8255, 0, 507);
+-- Adding vendor + token menu option (Vendor options will not show on non-vendor npcs)
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12852, 0, 1, 'I want to browse your goods.', 3, 4, 0, 0, 0, 0, 0, NULL, 500);
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12852, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 1285201, 0, 0, NULL, 517);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12852, 8283, 0, 508);
+-- No Cologne gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12852, 8287, 0, 519);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12852, 8296, 0, 518);
+-- Cast Valentine(27550) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1285201, 0, 15, 27550, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Alliance Civilian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1285201, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12852, 8291, 0, 524);
+
+-- Alliance Nightelf Civilian Male template - Gossip Menu + Options (Vendor options will not show on non-vendor npcs)
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12853, 8255, 0, 507);
+-- Adding vendor + token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12853, 0, 1, 'I want to browse your goods.', 3, 4, 0, 0, 0, 0, 0, NULL, 500);
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12853, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 1285301, 0, 0, NULL, 523);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12853, 8283, 0, 508);
+-- No Perfume gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12853, 8289, 0, 520);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12853, 8296, 0, 518);
+-- Cast Valentine(27550) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1285301, 0, 15, 27550, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Alliance Civilian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1285301, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12853, 8291, 0, 524);
+
+-- Alliance Gnome Civilian Female template - Gossip Menu + Options 
+
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12854, 8254, 0, 507);
+-- Adding vendor + token menu option (Vendor options will not show on non-vendor npcs)
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12854, 0, 1, 'I want to browse your goods.', 3, 4, 0, 0, 0, 0, 0, NULL, 500);
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12854, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 1285401, 0, 0, NULL, 517);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12854, 8283, 0, 508);
+-- No Cologne gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12854, 8287, 0, 519);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12854, 8296, 0, 518);
+-- Cast Valentine(27550) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1285401, 0, 15, 27550, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Alliance Civilian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1285401, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12854, 8291, 0, 524);
+
+-- Alliance Gnome Civilian Male template - Gossip Menu + Options 
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12855, 8254, 0, 507);
+-- Adding vendor + token menu option (Vendor options will not show on non-vendor npcs)
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12855, 0, 1, 'I want to browse your goods.', 3, 4, 0, 0, 0, 0, 0, NULL, 500);
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12855, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 1285501, 0, 0, NULL, 523);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12855, 8283, 0, 508);
+-- No Perfume gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12855, 8289, 0, 520);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12855, 8296, 0, 518);
+-- Cast Valentine(27550) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1285501, 0, 15, 27550, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Alliance Civilian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1285501, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12855, 8291, 0, 524);
+
+-- SW vendors have generic gossip for each quarter.  The entries below enhance these gossip menus to allow for love token interactions.
+-- Alliance Human Civilian Female template - Gossip Menu + Options Mage Quarter
+
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (681, 8245, 0, 507);
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (681, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 68501, 0, 0, NULL, 517);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (681, 8283, 0, 508);
+-- No Cologne gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (681, 8287, 0, 519);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (681, 8296, 0, 518);
+-- Cast Valentine(27550) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (68101, 0, 15, 27550, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Alliance Civilian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (68101, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (681, 8291, 0, 524);
+
+-- Alliance Human Civilian Male template - Gossip Menu + Options  Mage Quarter
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (682, 8245, 0, 507);
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (682, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 68601, 0, 0, NULL, 523);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (682, 8283, 0, 508);
+-- No Perfume gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (682, 8289, 0, 520);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (682, 8296, 0, 518);
+-- Cast Valentine(27550) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (68201, 0, 15, 27550, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Alliance Civilian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (68201, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (682, 8291, 0, 524);
+
+-- Alliance Human Civilian Female template - Gossip Menu + Options Trade Quarter
+
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (685, 8245, 0, 507);
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (685, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 68501, 0, 0, NULL, 517);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (685, 8283, 0, 508);
+-- No Cologne gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (685, 8287, 0, 519);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (685, 8296, 0, 518);
+-- Cast Valentine(27550) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (68501, 0, 15, 27550, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Alliance Civilian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (68501, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (685, 8291, 0, 524);
+
+-- Alliance Human Civilian Male template - Gossip Menu + Options  Trade Quarter
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (686, 8245, 0, 507);
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (686, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 68601, 0, 0, NULL, 523);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (686, 8283, 0, 508);
+-- No Perfume gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (686, 8289, 0, 520);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (686, 8296, 0, 518);
+-- Cast Valentine(27550) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (68601, 0, 15, 27550, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Alliance Civilian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (68601, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (686, 8291, 0, 524);
+
+-- Alliance Human Civilian Female template - Gossip Menu + Options Cathedral Square
+
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (691, 8245, 0, 507);
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (691, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 69101, 0, 0, NULL, 517);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (691, 8283, 0, 508);
+-- No Cologne gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (691, 8287, 0, 519);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (691, 8296, 0, 518);
+-- Cast Valentine(27550) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (69101, 0, 15, 27550, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Alliance Civilian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (69101, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (691, 8291, 0, 524);
+
+-- Alliance Human Civilian Male template - Gossip Menu + Options  Cathedral Square
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (692, 8245, 0, 507);
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (692, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 69201, 0, 0, NULL, 523);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (692, 8283, 0, 508);
+-- No Perfume gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (692, 8289, 0, 520);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (692, 8296, 0, 518);
+-- Cast Valentine(27550) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (69201, 0, 15, 27550, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Alliance Civilian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (69201, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (692, 8291, 0, 524);
+
+-- Alliance Dwarf Civilian Female template - Gossip Menu + Options Dwarven District
+
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (693, 8251, 0, 507);
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (693, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 69301, 0, 0, NULL, 517);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (693, 8283, 0, 508);
+-- No Cologne gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (693, 8287, 0, 519);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (693, 8296, 0, 518);
+-- Cast Valentine(27550) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (69301, 0, 15, 27550, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Alliance Civilian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (69301, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (693, 8291, 0, 524);
+
+-- Alliance Dwarf Civilian Male template - Gossip Menu + Options  Dwarven District
+-- Adding gossip_menu, gossip_menu_option and npc_text entries to support male template (it seems to be missing)
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (694, 1244, 0, 0);
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (694, 0, 1, 'I want to browse your goods.', 3, 4, 0, 0, 0, 0, 0, '', 0);
+INSERT INTO `npc_text` (`ID`, `text0_0`, `text0_1`, `lang0`, `prob0`, `em0_0`, `em0_1`, `em0_2`, `em0_3`, `em0_4`, `em0_5`, `text1_0`, `text1_1`, `lang1`, `prob1`, `em1_0`, `em1_1`, `em1_2`, `em1_3`, `em1_4`, `em1_5`, `text2_0`, `text2_1`, `lang2`, `prob2`, `em2_0`, `em2_1`, `em2_2`, `em2_3`, `em2_4`, `em2_5`, `text3_0`, `text3_1`, `lang3`, `prob3`, `em3_0`, `em3_1`, `em3_2`, `em3_3`, `em3_4`, `em3_5`, `text4_0`, `text4_1`, `lang4`, `prob4`, `em4_0`, `em4_1`, `em4_2`, `em4_3`, `em4_4`, `em4_5`, `text5_0`, `text5_1`, `lang5`, `prob5`, `em5_0`, `em5_1`, `em5_2`, `em5_3`, `em5_4`, `em5_5`, `text6_0`, `text6_1`, `lang6`, `prob6`, `em6_0`, `em6_1`, `em6_2`, `em6_3`, `em6_4`, `em6_5`, `text7_0`, `text7_1`, `lang7`, `prob7`, `em7_0`, `em7_1`, `em7_2`, `em7_3`, `em7_4`, `em7_5`) VALUES (1244, 'Don\'t let the humans in the Bazaar fool ye $g lad : lass;, with the subway those gnomes built it\'s easier than ye might think to transport goods from Ironforge. If they try to tack on import fees just tell them yer gonna buy yer gear from me.', 'Don\'t let the humans in the Bazaar fool ye $g lad : lass;, with the subway those gnomes built it\'s easier than ye might think to transport goods from Ironforge. If they try to tack on import fees just tell them yer gonna buy yer gear from me.', 7, 100, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0);
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (694, 8251, 0, 507);
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (694, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 69401, 0, 0, NULL, 523);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (694, 8283, 0, 508);
+-- No Perfume gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (694, 8289, 0, 520);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (694, 8296, 0, 518);
+-- Cast Valentine(27550) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (69401, 0, 15, 27550, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Alliance Civilian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (69401, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (694, 8291, 0, 524);
+
+-- Alliance Gnome Civilian Female template - Gossip Menu + Options Dwarven District
+-- Adding gossip_menu, gossip_menu_option and npc_text entries to support male template (it seems to be missing)
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (697, 1248, 0, 0);
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (697, 0, 1, 'I want to browse your goods.', 3, 4, 0, 0, 0, 0, 0, '', 0);
+INSERT INTO `npc_text` (`ID`, `text0_0`, `text0_1`, `lang0`, `prob0`, `em0_0`, `em0_1`, `em0_2`, `em0_3`, `em0_4`, `em0_5`, `text1_0`, `text1_1`, `lang1`, `prob1`, `em1_0`, `em1_1`, `em1_2`, `em1_3`, `em1_4`, `em1_5`, `text2_0`, `text2_1`, `lang2`, `prob2`, `em2_0`, `em2_1`, `em2_2`, `em2_3`, `em2_4`, `em2_5`, `text3_0`, `text3_1`, `lang3`, `prob3`, `em3_0`, `em3_1`, `em3_2`, `em3_3`, `em3_4`, `em3_5`, `text4_0`, `text4_1`, `lang4`, `prob4`, `em4_0`, `em4_1`, `em4_2`, `em4_3`, `em4_4`, `em4_5`, `text5_0`, `text5_1`, `lang5`, `prob5`, `em5_0`, `em5_1`, `em5_2`, `em5_3`, `em5_4`, `em5_5`, `text6_0`, `text6_1`, `lang6`, `prob6`, `em6_0`, `em6_1`, `em6_2`, `em6_3`, `em6_4`, `em6_5`, `text7_0`, `text7_1`, `lang7`, `prob7`, `em7_0`, `em7_1`, `em7_2`, `em7_3`, `em7_4`, `em7_5`) VALUES (1248, 'If you insert tab A into slot B then of course it\'s going to go BOOM! Here, let me show you what I have and then you can ask Lilliam about how to put it together so it doesn\'t blow up.', 'If you insert tab A into slot B then of course it\'s going to go BOOM! Here, let me show you what I have and then you can ask Lilliam about how to put it together so it doesn\'t blow up.', 7, 100, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0);
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (697, 8254, 0, 507);
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (697, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 69701, 0, 0, NULL, 517);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (693, 8283, 0, 508);
+-- No Cologne gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (693, 8287, 0, 519);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (693, 8296, 0, 518);
+-- Cast Valentine(27550) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (69701, 0, 15, 27550, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Alliance Civilian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (69701, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (693, 8291, 0, 524);
+
+-- Alliance Gnome Civilian Male template - Gossip Menu + Options  Dwarven District
+
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (698, 8254, 0, 507);
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (698, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 69801, 0, 0, NULL, 523);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (698, 8283, 0, 508);
+-- No Perfume gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (698, 8289, 0, 520);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (698, 8296, 0, 518);
+-- Cast Valentine(27550) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (69801, 0, 15, 27550, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Alliance Civilian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (69801, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (698, 8291, 0, 524);
+
+-- Alliance Human Civilian Female template - Gossip Menu + Options Old Town
+
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (688, 8245, 0, 507);
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (688, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 68801, 0, 0, NULL, 517);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (688, 8283, 0, 508);
+-- No Cologne gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (688, 8287, 0, 519);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (688, 8296, 0, 518);
+-- Cast Valentine(27550) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (68801, 0, 15, 27550, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Alliance Civilian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (68801, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (688, 8291, 0, 524);
+
+-- Alliance Human Civilian Male template - Gossip Menu + Options  Old Town
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (689, 0, 1, 'I want to browse your goods.', 3, 4, 0, 0, 0, 0, 0, NULL, 0);
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (689, 8245, 0, 507);
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (689, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 68901, 0, 0, NULL, 523);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (689, 8283, 0, 508);
+-- No Perfume gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (689, 8289, 0, 520);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (689, 8296, 0, 518);
+-- Cast Valentine(27550) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (68901, 0, 15, 27550, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Alliance Civilian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (68901, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (689, 8291, 0, 524);
+
+-- Tauren Civilian Female template - Gossip Menu + Options 
+
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12856, 8254, 0, 507);
+-- Adding vendor + token menu option (Vendor options will not show on non-vendor npcs)
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12856, 0, 1, 'I want to browse your goods.', 3, 4, 0, 0, 0, 0, 0, NULL, 500);
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12856, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 1285601, 0, 0, NULL, 517);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12856, 8283, 0, 508);
+-- No Cologne gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12856, 8287, 0, 519);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12856, 8296, 0, 518);
+-- Cast Valentine(27550) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1285601, 0, 15, 27549, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Horde Civilian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1285601, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12856, 8291, 0, 524);
+
+-- Tauren Civilian Male template - Gossip Menu + Options 
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12857, 8254, 0, 507);
+-- Adding vendor + token menu option (Vendor options will not show on non-vendor npcs)
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12857, 0, 1, 'I want to browse your goods.', 3, 4, 0, 0, 0, 0, 0, NULL, 500);
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12857, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 1285701, 0, 0, NULL, 523);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12857, 8283, 0, 508);
+-- No Perfume gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12857, 8289, 0, 520);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12857, 8296, 0, 518);
+-- Cast Valentine(27550) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1285701, 0, 15, 27549, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Horde Civilian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1285701, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12857, 8291, 0, 524);
+
+
+-- Forsaken Civilian Female template - Gossip Menu + Options 
+
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12858, 8270, 0, 507);
+-- Adding vendor + token menu option (Vendor options will not show on non-vendor npcs)
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12858, 0, 1, 'I want to browse your goods.', 3, 4, 0, 0, 0, 0, 0, NULL, 500);
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12858, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 1285801, 0, 0, NULL, 517);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12858, 8283, 0, 508);
+-- No Cologne gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12858, 8287, 0, 519);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12858, 8296, 0, 518);
+-- Cast Valentine(27550) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1285801, 0, 15, 27549, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Horde Civilian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1285801, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12858, 8291, 0, 524);
+
+-- Forsaken Civilian Male template - Gossip Menu + Options 
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12859, 8270, 0, 507);
+-- Adding vendor + token menu option (Vendor options will not show on non-vendor npcs)
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12859, 0, 1, 'I want to browse your goods.', 3, 4, 0, 0, 0, 0, 0, NULL, 500);
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12859, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 1285901, 0, 0, NULL, 523);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12859, 8283, 0, 508);
+-- No Perfume gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12859, 8289, 0, 520);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12859, 8296, 0, 518);
+-- Cast Valentine(27550) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1285901, 0, 15, 27549, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Horde Civilian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1285901, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12859, 8291, 0, 524);
+
+-- Orc Civilian Female template - Gossip Menu + Options 
+
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12868, 8265, 0, 507);
+-- Adding vendor + token menu option (Vendor options will not show on non-vendor npcs)
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12868, 0, 1, 'I want to browse your goods.', 3, 4, 0, 0, 0, 0, 0, NULL, 500);
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12868, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 1286801, 0, 0, NULL, 517);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12868, 8283, 0, 508);
+-- No Cologne gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12868, 8287, 0, 519);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12868, 8296, 0, 518);
+-- Cast Valentine(27550) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1286801, 0, 15, 27549, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Horde Civilian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1286801, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12868, 8291, 0, 524);
+
+-- Orc Civilian Male template - Gossip Menu + Options 
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12869, 8265, 0, 507);
+-- Adding vendor + token menu option (Vendor options will not show on non-vendor npcs)
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12869, 0, 1, 'I want to browse your goods.', 3, 4, 0, 0, 0, 0, 0, NULL, 500);
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12869, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 1286901, 0, 0, NULL, 523);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12869, 8283, 0, 508);
+-- No Perfume gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12869, 8289, 0, 520);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12869, 8296, 0, 518);
+-- Cast Valentine(27550) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1286901, 0, 15, 27549, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Horde Civilian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1286901, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12869, 8291, 0, 524);
+
+
+-- Generic Alliance Human Civilian Male template - Gossip Menu + Options
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12863, 8245, 0, 507);
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12863, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 1286301, 0, 0, NULL, 523);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12863, 8283, 0, 508);
+-- No Perfume gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12863, 8289, 0, 520);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12863, 8296, 0, 518);
+-- Cast Valentine(27550) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1286301, 0, 15, 27550, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Alliance Civilian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1286301, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12863, 8291, 0, 524);
+
+-- Generic Horde Civilian Female template - Gossip Menu + Options
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12872, 8245, 0, 507);
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12872, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 1287201, 0, 0, NULL, 517);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12872, 8283, 0, 508);
+-- No Perfume gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12872, 8287, 0, 520);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12872, 8296, 0, 518);
+-- Cast Valentine(27550) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1287201, 0, 15, 27549, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Horde Civilian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1287201, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12872, 8291, 0, 524);
+
+-- Generic Horde Civilian Male template - Gossip Menu + Options
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12873, 8245, 0, 507);
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12873, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 1287301, 0, 0, NULL, 523);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12873, 8283, 0, 508);
+-- No Perfume gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12873, 8289, 0, 520);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12873, 8296, 0, 518);
+-- Cast Valentine(27550) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1287301, 0, 15, 27549, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Horde Civilian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1287301, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12873, 8291, 0, 524);
+

--- a/Updates/Conditions.sql
+++ b/Updates/Conditions.sql
@@ -73,3 +73,41 @@ INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES 
 -- To Not have perfume or cologne aura and Love is in the air active(530)
 INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (529, -3, 525, 0);
 INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (530, -1, 500, 529);
+
+-- NPC Female (SW City Guard and Patrollers)
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (531, 40, 2, 0);
+
+-- NPC Female (Org Grunts and Bluffwatchers)
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (532, 40, 1, 0);
+
+-- NPC Male
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (533, 40, 0, 0);
+
+-- Condition Love is in the Air Active, player NOT heartbroken and Guard NPC Female (SW City Guard and Patrollers)
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (534, -1, 507, 531);
+
+-- Condition Love is in the Air Active, player NOT heartbroken and Guard NPC Female (Org Grunts and Bluffwatchers)
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (535, -1, 507, 532);
+
+-- Condition Love is in the Air Active, player NOT heartbroken and Guard NPC Male
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (536, -1, 507, 533);
+
+-- Conditon entry for love token gossip (cologne only) and Guard NPC Female (SW City Guard and Patrollers)
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (537, -1, 517, 531);
+
+-- Conditon entry for love token gossip (cologne only) and Guard NPC Female (Org Grunts and Bluffwatchers)
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (538, -1, 517, 532);
+
+-- Conditon entry for love token gossip (perfume only) and Guard NPC Male
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (539, -1, 523, 533);
+
+-- No Cologne Aura and Love is in the Air Active and Guard NPC Female (SW City Guard and Patrollers)
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (540, -1, 519, 531);
+
+-- No Cologne Aura and Love is in the Air Active and Guard NPC Female (Org Grunts and Bluffwatchers)
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (541, -1, 519, 532);
+
+-- No Perfume Aura and Love is in the Air Active and Guard NPC Male
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (542, -1, 520, 533);
+
+

--- a/Updates/Conditions.sql
+++ b/Updates/Conditions.sql
@@ -1,0 +1,75 @@
+-- ********************************Conditions**********************************************************
+
+/* Adding condition support for requiring Love is in the Air to be active and NOT active */
+
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (500, 12, 8, 0);
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (501, 25, 8, 0);
+
+-- Condition to have perfume aura
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (502, 1, 26682, 0);
+
+-- Condition to have cologne aura
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (503, 1, 26681, 0);
+
+-- Condition to have adored aura 
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (504, 1, 26680, 0);
+
+-- Conditions to have and not have heartbroken aura
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (505, 1, 26898, 0);
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (506, 11, 26898, 0);
+
+-- Condition Love is in the Air Active and NOT heartbroken
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (507, -1, 500, 506);
+
+-- Condition Love is in the Air Active and heartbroken
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (508, -1, 500, 505);
+
+-- Condition to have Love is in the Air Aura (NPC)
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (509, 32, 27741, 0);
+
+-- To have Cologne Aura and Love is in the Air Active
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (510, -1, 500, 503);
+
+-- Conditions to not have perfume or cologne auras
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (511, 11, 26681, 0);
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (512, 11, 26682, 0);
+
+-- Conditions to have/not have Love Tokens in inventory
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (513, 23, 21815, 1);
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (514, 24, 21815, 1);
+
+-- Creating multiple conditon entry for love token gossip (cologne only)
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (515, -1, 506, 509);
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (516, -1, 510, 513);
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (517, -1, 515, 516);
+
+-- Adored and Love is in the Air Active
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (518, -1, 500, 504);
+
+-- No Cologne Aura and Love is in the Air Active
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (519, -1, 500, 511);
+
+-- No Perfume Aura and Love is in the Air Active
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (520, -1, 500, 512);
+
+-- To have Perfume Aura and Love is in the Air Active
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (521, -1, 500, 502);
+
+-- Creating multiple conditon entry for love token gossip (perfume only)
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (522, -1, 513, 521);
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (523, -1, 515, 522);
+
+-- No tokens in inventory and event active
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (524, -1, 500, 514);
+
+-- To have perfume or cologne aura and love is in the air active
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (525, -2, 502, 503);
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (526, -1, 500, 525);
+
+-- Creating multiple conditon entry for love token gossip (cologne or perfume for UC Guardians)
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (527, -1, 513, 526);
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (528, -1, 515, 527);
+
+-- To Not have perfume or cologne aura and Love is in the air active(530)
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (529, -3, 525, 0);
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`) VALUES (530, -1, 500, 529);

--- a/Updates/Darnassus Civilians.sql
+++ b/Updates/Darnassus Civilians.sql
@@ -1,0 +1,302 @@
+-- Darnassus Civilians
+
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46560, 0, 0, 0, 27654, 0, 8); -- Mythrin'dir *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46723, 0, 0, 0, 27654, 0, 8); -- Mydrannul
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (48217, 0, 0, 0, 27654, 0, 8); -- Shylenai *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46346, 0, 0, 0, 27654, 0, 8); -- Fyrenna *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46905, 0, 0, 0, 27654, 0, 8); -- Jareth Wildwoods *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46333, 0, 0, 0, 27654, 0, 8); -- Jaeana *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46569, 0, 0, 0, 27654, 0, 8); -- Andrus *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46338, 0, 0, 0, 27654, 0, 8); -- Anadyia *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46576, 0, 0, 0, 27654, 0, 8); -- Cyridan *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46344, 0, 0, 0, 27654, 0, 8); -- Melea *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46720, 0, 0, 0, 27654, 0, 8); -- Caynrus (Needs correct equip) *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46342, 0, 0, 0, 27654, 0, 8); -- Vinasia *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46345, 0, 0, 0, 27654, 0, 8); -- Dewwhisper *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46340, 0, 0, 0, 27654, 0, 8); -- Landria *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46571, 0, 0, 0, 27654, 0, 8); -- Turian *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46565, 0, 0, 0, 27654, 0, 8); -- Glorandiir *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46337, 0, 0, 0, 27654, 0, 8); -- Merelyssa *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46568, 0, 0, 0, 27654, 0, 8); -- Mythidan *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46564, 0, 0, 0, 27654, 0, 8); -- Kieran *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46335, 0, 0, 0, 27654, 0, 8); -- Ellandrieth *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46562, 0, 0, 0, 27654, 0, 8); -- Yldan *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46412, 0, 0, 0, 27654, 0, 8); -- Ariyell Skyshadow *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46315, 0, 0, 0, 27654, 0, 8); -- Cylania *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46329, 0, 0, 0, 27654, 0, 8); -- Shalumon
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46330, 0, 0, 0, 27654, 0, 8); -- Elynna *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46501, 0, 0, 0, 27654, 0, 8); -- Saenorion *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46508, 0, 0, 0, 27654, 0, 8); -- Vaean *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46482, 0, 0, 0, 27654, 0, 8); -- Fyldan *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46503, 0, 0, 0, 27654, 0, 8); -- Ulthir *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46326, 0, 0, 0, 27654, 0, 8); -- Dendrythis *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46477, 0, 0, 0, 27654, 0, 8); -- Cyroen *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (49519, 0, 0, 0, 27654, 0, 8); -- Kyrai *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46481, 0, 0, 0, 27654, 0, 8); -- Voloren *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46479, 0, 0, 0, 27654, 0, 8); -- Talaelar *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (49525, 0, 0, 0, 27654, 0, 8); -- Alaindia *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46471, 0, 0, 0, 27654, 0, 8); -- Chardryn *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46885, 0, 0, 0, 27654, 0, 8); -- Treshala Fallowbrook *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46480, 0, 0, 0, 27654, 0, 8); -- Herald Moonstalker
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46898, 0, 0, 0, 27654, 0, 8); -- Sarin Starlight *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46904, 0, 0, 0, 27654, 0, 8); -- Rellian Greenspyre * (Although wowwiki say added 1.12)
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46802, 0, 0, 0, 27654, 0, 8); -- Lotherias *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46899, 0, 0, 0, 27654, 0, 8); -- Ellaercia *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (49935, 0, 0, 0, 27654, 0, 8); -- Mathiel *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (49540, 0, 0, 0, 27654, 0, 8); -- Faelyssa *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (49854, 0, 0, 0, 27654, 0, 8); -- Elanaria *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46816, 0, 0, 0, 27654, 0, 8); -- Crildor *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46812, 0, 0, 0, 27654, 0, 8); -- Sister Aquinne *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46353, 0, 0, 0, 27654, 0, 8); -- Greywhisker *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46238, 0, 0, 0, 27654, 0, 8); -- Gracina Spiritmight *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46721, 0, 0, 0, 27654, 0, 8); -- Priestess A'moora *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46348, 0, 0, 0, 27654, 0, 8); -- Thyn'tel Bladeweaver *
+
+
+-- Adding Gossip option during event and removing outside of event
+-- Vendors
+-- Shylenai
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 8665, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Shylenai');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 8665, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Shylenai');
+UPDATE `creature_template` SET `GossipMenuId`= 12852 WHERE `Entry`= 8665;
+
+-- Fyrenna
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4181, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Fyrenna');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4181, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Fyrenna');
+UPDATE `creature_template` SET `GossipMenuId`= 12852 WHERE `Entry`= 4181;
+
+-- Ellandrieth
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4170, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Ellandrieth');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4170, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Ellandrieth');
+UPDATE `creature_template` SET `GossipMenuId`= 12852 WHERE `Entry`= 4170;
+
+-- Yldan
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4230, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Yldan');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4230, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Yldan');
+UPDATE `creature_template` SET `GossipMenuId`= 12853 WHERE `Entry`= 4230;
+
+-- Glorandiir
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4232, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Glorandiir');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4232, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Glorandiir');
+UPDATE `creature_template` SET `GossipMenuId`= 12853 WHERE `Entry`= 4232;
+
+-- Merelyssa
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4171, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Merelyssa');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4171, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Merelyssa');
+UPDATE `creature_template` SET `GossipMenuId`= 12852 WHERE `Entry`= 4171;
+
+-- Mythidan
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4233, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Mythidan');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4233, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Mythidan');
+UPDATE `creature_template` SET `GossipMenuId`= 12853 WHERE `Entry`= 4233;
+
+-- Kieran
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4231, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Kieran');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4231, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Kieran');
+UPDATE `creature_template` SET `GossipMenuId`= 12853 WHERE `Entry`= 4231;
+
+-- Jaeana
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4169, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Jaeana');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4169, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Jaeana');
+UPDATE `creature_template` SET `GossipMenuId`= 12852 WHERE `Entry`= 4169;
+
+-- Landria
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4173, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Landria');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4173, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Landria');
+UPDATE `creature_template` SET `GossipMenuId`= 12852 WHERE `Entry`= 4173;
+
+-- Turian
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4235, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Turian');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4235, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Turian');
+UPDATE `creature_template` SET `GossipMenuId`= 12853 WHERE `Entry`= 4235;
+
+-- Vinasia
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4175, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Vinasia');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4175, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Vinasia');
+UPDATE `creature_template` SET `GossipMenuId`= 12852 WHERE `Entry`= 4175;
+
+-- Dewwhisper
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4180, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Dewwhisper');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4180, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Dewwhisper');
+UPDATE `creature_template` SET `GossipMenuId`= 12852 WHERE `Entry`= 4180;
+
+-- Melea
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4177, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Melea');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4177, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Melea');
+UPDATE `creature_template` SET `GossipMenuId`= 12852 WHERE `Entry`= 4177;
+
+-- Caynrus
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4240, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Caynrus');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4240, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Caynrus');
+UPDATE `creature_template` SET `GossipMenuId`= 12853 WHERE `Entry`= 4240;
+
+-- Cyridan
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4236, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Cyridan');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4236, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Cyridan');
+UPDATE `creature_template` SET `GossipMenuId`= 12853 WHERE `Entry`= 4236;
+
+-- Andrus
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4234, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Andrus');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4234, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Andrus');
+UPDATE `creature_template` SET `GossipMenuId`= 12853 WHERE `Entry`= 4234;
+
+-- Anadyia
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4172, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Anadyia');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4172, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Anadyia');
+UPDATE `creature_template` SET `GossipMenuId`= 12852 WHERE `Entry`= 4172;
+
+-- Elynna
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4168, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Elynna');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4168, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Elynna');
+UPDATE `creature_template` SET `GossipMenuId`= 12852 WHERE `Entry`= 4168;
+
+-- Saenorion
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4225, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Saenorion');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4225, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Saenorion');
+UPDATE `creature_template` SET `GossipMenuId`= 12853 WHERE `Entry`= 4225;
+
+-- Mythrin'dir
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4229, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Mythrindir');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4229, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Mythrindir');
+UPDATE `creature_template` SET `GossipMenuId`= 12853 WHERE `Entry`= 4229;
+
+-- Vaean
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4228, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Vaean');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4228, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Vaean');
+UPDATE `creature_template` SET `GossipMenuId`= 12853 WHERE `Entry`= 4228;
+
+-- Fyldan
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4223, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Fyldan');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4223, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Fyldan');
+UPDATE `creature_template` SET `GossipMenuId`= 12853 WHERE `Entry`= 4223;
+
+-- Ulthir
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4226, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Ulthir');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4226, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Ulthir');
+UPDATE `creature_template` SET `GossipMenuId`= 12853 WHERE `Entry`= 4226;
+
+-- Kyrai
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3561, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Kyrai');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3561, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Kyrai');
+UPDATE `creature_template` SET `GossipMenuId`= 12852 WHERE `Entry`= 3561;
+
+-- Cyroen
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4220, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Cyroen');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4220, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Cyroen');
+UPDATE `creature_template` SET `GossipMenuId`= 12853 WHERE `Entry`= 4220;
+
+-- Ariyell Skyshadow
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4203, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Ariyell');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4203, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Ariyell');
+UPDATE `creature_template` SET `GossipMenuId`= 12852 WHERE `Entry`= 4203;
+
+-- Cylania
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4164, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Cylania');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4164, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Cylania');
+UPDATE `creature_template` SET `GossipMenuId`= 12852 WHERE `Entry`= 4164;
+
+-- Talaelar
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4221, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Talaelar');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4221, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Talaelar');
+UPDATE `creature_template` SET `GossipMenuId`= 12853 WHERE `Entry`= 4221;
+
+-- Voloren
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4222, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Voloren');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4222, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Voloren');
+UPDATE `creature_template` SET `GossipMenuId`= 12853 WHERE `Entry`= 4222;
+
+-- Alaindia
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3562, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Alaindia');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3562, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Alaindia');
+UPDATE `creature_template` SET `GossipMenuId`= 12852 WHERE `Entry`= 3562;
+
+-- Chardryn
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4216, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Chardryn');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4216, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Chardryn');
+UPDATE `creature_template` SET `GossipMenuId`= 12853 WHERE `Entry`= 4216;
+
+-- Dendrythis
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4167, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Dendrythis');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4167, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Dendrythis');
+UPDATE `creature_template` SET `GossipMenuId`= 12852 WHERE `Entry`= 4167;
+
+
+-- Questgiver
+-- Treshala Fallowbrook
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4521, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Treshala');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4521, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Treshala');
+UPDATE `creature_template` SET `GossipMenuId`= 12852 WHERE `Entry`= 4521;
+
+-- Lotherias
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 6034, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Lotherias');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 6034, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Lotherias');
+UPDATE `creature_template` SET `GossipMenuId`= 12852 WHERE `Entry`= 6034;
+
+-- Rellian Greenspyre
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3517, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Rellian');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3517, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from rellian');
+UPDATE `creature_template` SET `GossipMenuId`= 12853 WHERE `Entry`= 3517;
+
+-- Elanaria
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4088, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Elanaria');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4088, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Elanaria');
+UPDATE `creature_template` SET `GossipMenuId`= 12852 WHERE `Entry`= 4088;
+
+-- Mathiel
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 6142, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Mathiel');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 6142, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Mathiel');
+UPDATE `creature_template` SET `GossipMenuId`= 12853 WHERE `Entry`= 6142;
+
+-- Sister Aquinne
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 7316, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Aquinne');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 7316, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Aquinne');
+UPDATE `creature_template` SET `GossipMenuId`= 12852 WHERE `Entry`= 7316;
+
+-- Greywhisker
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 2912, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Greywhisker');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 2912, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Greywhisker');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 2912;
+
+-- Gracina Spiritmight
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 7740, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Gracina');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 7740, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Gracina');
+UPDATE `creature_template` SET `GossipMenuId`= 12852 WHERE `Entry`= 7740;
+
+-- Priestess A'moora
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 7313, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Amoora');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 7313, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Amoora');
+UPDATE `creature_template` SET `GossipMenuId`= 12852 WHERE `Entry`= 7313;
+
+-- Thyn'tel Bladewever
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 7313, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Thyntel');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 7313, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Thyntel');
+UPDATE `creature_template` SET `GossipMenuId`= 12852 WHERE `Entry`= 8026;
+
+-- Non Questgiver/Vendor
+-- Jareth Wildwoods
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 11709, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Jareth');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 11709, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Jareth');
+UPDATE `creature_template` SET `GossipMenuId`= 12853 WHERE `Entry`= 11709;
+
+-- Ellaercia
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5407, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Ellaercia');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5407, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Ellaercia');
+UPDATE `creature_template` SET `GossipMenuId`= 12852 WHERE `Entry`= 5407;
+
+-- Faelyssa
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 2796, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Faelyssa');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 2796, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Faelyssa');
+UPDATE `creature_template` SET `GossipMenuId`= 12852 WHERE `Entry`= 2796;
+
+-- Crildor
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5782, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Crildor');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5782, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Crildor');
+UPDATE `creature_template` SET `GossipMenuId`= 12853 WHERE `Entry`= 5782;
+
+-- Sarin Starlight
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 11700, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Sarin');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 11700, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Sarin');
+UPDATE `creature_template` SET `GossipMenuId`= 12853 WHERE `Entry`= 11700;
+
+
+-- Sentinel Dalia Sunblade (faction 124), Lysheana, Shalumon, Jenal (specific gossips)

--- a/Updates/Darnassus Sentinels.sql
+++ b/Updates/Darnassus Sentinels.sql
@@ -1,0 +1,114 @@
+-- Darnassus Sentinels gossip + Menu
+
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46820, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46821, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46822, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46823, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46824, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46825, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46826, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46828, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46829, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46830, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46831, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46832, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46833, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46834, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46835, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46836, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46837, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46838, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46839, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46840, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46841, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46843, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46844, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46845, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46846, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46847, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46848, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46849, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46852, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46853, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46854, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46855, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46880, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46881, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46882, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46883, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46884, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (49939, 0, 0, 0, 27654, 0, 8);
+
+-- Huntresses
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46216, 0, 0, 0, 27654, 0, 8); -- Skymane
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46219, 0, 0, 0, 27654, 0, 8); -- Ravenoak
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46220, 0, 0, 0, 27654, 0, 8); -- Leafrunner
+
+-- Adding gossip and conditions
+
+-- Sentinels
+-- Changing standard gossip to display only outside of event
+UPDATE `gossip_menu` SET `condition_id`= 501 WHERE `entry`= 10265 and `text_id`= 3016;
+
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (10265, 8255, 0, 507);
+
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (10265, 11, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 0, 0, 0, NULL, 517);
+
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (10265, 8283, 0, 508);
+
+-- No Cologne gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (10265, 8287, 0, 519);
+
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (10265, 8296, 0, 518);
+
+-- Cast Valentine(27541) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1026501, 0, 15, 27541, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Darn Sentinel on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1026501, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+UPDATE `gossip_menu_option` SET `action_script_id`= 1026501 WHERE `menu_id`= 10265 AND `id`= 11;
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (10265, 8291, 0, 524);
+
+-- Huntresses
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12866, 8255, 0, 507);
+
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12866, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 0, 0, 0, NULL, 517);
+
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12866, 8283, 0, 508);
+
+-- No Cologne gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12866, 8287, 0, 519);
+
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12866, 8296, 0, 518);
+
+-- Cast Valentine(27541) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1286601, 0, 15, 27541, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Darn Sentinel on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1286601, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12866, 8291, 0, 524);
+
+-- Huntress Skymane
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 14378, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Skymane');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 14378, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Skymane');
+UPDATE `creature_template` SET `GossipMenuId`= 12866 WHERE `Entry`= 14378;
+
+-- Huntress Ravenoak
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 14379, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Ravenoak');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 14379, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Ravenoak');
+UPDATE `creature_template` SET `GossipMenuId`= 12866 WHERE `Entry`= 14379;
+
+-- Huntress Leafrunner
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 14380, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Leafrunner');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 14380, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Leafrunner');
+UPDATE `creature_template` SET `GossipMenuId`= 12866 WHERE `Entry`= 14380;

--- a/Updates/Innkeepers.sql
+++ b/Updates/Innkeepers.sql
@@ -1,0 +1,373 @@
+/* Adding Event items (Love tokens, Perfume and Cologne) to innkeepers */
+
+-- Capitals
+-- Allison
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6740, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6740, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6740, 21833, 0, 0, 500);
+-- Firebrew
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (5111, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (5111, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (5111, 21833, 0, 0, 500);
+-- Saelienne
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6735, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6735, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6735, 21833, 0, 0, 500);
+-- Gryshka
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6929, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6929, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6929, 21833, 0, 0, 500);
+-- Pala
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6746, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6746, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6746, 21833, 0, 0, 500);
+-- Norman
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6741, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6741, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6741, 21833, 0, 0, 500);
+
+-- Kalimdor
+-- Keldamyr
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6736, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6736, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6736, 21833, 0, 0, 500);
+-- Shaussiy
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6737, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6737, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6737, 21833, 0, 0, 500);
+-- Kimlya
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6738, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6738, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6738, 21833, 0, 0, 500);
+-- Vizzie
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (11118, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (11118, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (11118, 21833, 0, 0, 500);
+-- Faralia
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (16458, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (16458, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (16458, 21833, 0, 0, 500);
+-- Lyshaerya
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (11103, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (11103, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (11103, 21833, 0, 0, 500);
+-- Wiley
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6791, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6791, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6791, 21833, 0, 0, 500);
+-- Janene
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6272, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6272, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6272, 21833, 0, 0, 500);
+-- Shyria
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (7736, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (7736, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (7736, 21833, 0, 0, 500);
+-- Calandrath
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (15174, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (15174, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (15174, 21833, 0, 0, 500);
+-- Fizzgrimble
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (7733, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (7733, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (7733, 21833, 0, 0, 500);
+-- Kaylisk
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (12196, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (12196, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (12196, 21833, 0, 0, 500);
+-- Grosk
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6928, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6928, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6928, 21833, 0, 0, 500);
+-- Booran Plainswind
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (3934, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (3934, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (3934, 21833, 0, 0, 500);
+-- Byula
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (7714, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (7714, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (7714, 21833, 0, 0, 500);
+-- Kauth
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6747, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6747, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6747, 21833, 0, 0, 500);
+-- Jayka
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (7731, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (7731, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (7731, 21833, 0, 0, 500);
+-- Sikewa
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (11106, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (11106, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (11106, 21833, 0, 0, 500);
+-- Greul
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (7737, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (7737, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (7737, 21833, 0, 0, 500);
+-- Abeqwa
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (11116, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (11116, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (11116, 21833, 0, 0, 500);
+
+-- EK
+-- Farley
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (295, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (295, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (295, 21833, 0, 0, 500);
+
+-- Heather
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (8931, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (8931, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (8931, 21833, 0, 0, 500);
+
+-- Brianna
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6727, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6727, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6727, 21833, 0, 0, 500);
+
+-- Trelayne
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6790, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6790, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6790, 21833, 0, 0, 500);
+
+-- Skindle
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6807, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6807, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6807, 21833, 0, 0, 500);
+
+-- Hearthstove
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6734, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6734, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6734, 21833, 0, 0, 500);
+
+-- Belm
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (1247, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (1247, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (1247, 21833, 0, 0, 500);
+
+-- Helbrek
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (1464, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (1464, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (1464, 21833, 0, 0, 500);
+
+-- Anderson
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (2352, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (2352, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (2352, 21833, 0, 0, 500);
+
+-- Thulfram
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (7744, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (7744, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (7744, 21833, 0, 0, 500);
+
+-- Jessica Chambers
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (16256, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (16256, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (16256, 21833, 0, 0, 500);
+
+-- Renee
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (5688, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (5688, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (5688, 21833, 0, 0, 500);
+
+-- Bates
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6739, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6739, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6739, 21833, 0, 0, 500);
+
+-- Shay
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (2388, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (2388, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (2388, 21833, 0, 0, 500);
+
+-- Lard
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (14731, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (14731, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (14731, 21833, 0, 0, 500);
+
+-- Adegwa
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (9501, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (9501, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (9501, 21833, 0, 0, 500);
+
+-- Shul'kar
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (9356, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (9356, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (9356, 21833, 0, 0, 500);
+
+-- Karakul
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6930, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6930, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (6930, 21833, 0, 0, 500);
+
+-- Thulbek
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (5814, 21815, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (5814, 21829, 0, 0, 500);
+INSERT INTO `npc_vendor` (`entry`, `item`, `maxcount`, `incrtime`, `condition_id`) VALUES (5814, 21833, 0, 0, 500);
+
+/* Adding more charges to Pefurme Bottle. You can never stop at 1 */
+
+UPDATE `item_template` SET `spellcharges_1`= -10 WHERE `entry`= 21829;
+
+/* Placing heart above innkeepers for the duration of the festival */
+-- Capitals
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79841, 0, 0, 0, 27654, 0, 8); -- Allison
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1745, 0, 0, 0, 27654, 0, 8); -- Firebrew
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46341, 0, 0, 0, 27654, 0, 8); -- Saelienne
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (4661, 0, 0, 0, 27654, 0, 8); -- Gryshka
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24772, 0, 0, 0, 27654, 0, 8); -- Pala
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38407, 0, 0, 0, 27654, 0, 8); -- Norman
+-- Kalimdor
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46343, 0, 0, 0, 27654, 0, 8); -- Keldamyr
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (37069, 0, 0, 0, 27654, 0, 8); -- Shaussiy
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (32451, 0, 0, 0, 27654, 0, 8); -- Kimlya
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (42181, 0, 0, 0, 27654, 0, 8); -- Vizzie
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (29239, 0, 0, 0, 27654, 0, 8); -- Faralia
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (28304, 0, 0, 0, 27654, 0, 8); -- Lyshaerya
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (14986, 0, 0, 0, 27654, 0, 8); -- Wiley
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (30676, 0, 0, 0, 27654, 0, 8); -- Janene
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (50059, 0, 0, 0, 27654, 0, 8); -- Shyria
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (42755, 0, 0, 0, 27654, 0, 8); -- Calandrath
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (22681, 0, 0, 0, 27654, 0, 8); -- Fizzgrimble
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (33073, 0, 0, 0, 27654, 0, 8); -- Kaylisk
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (7671, 0, 0, 0, 27654, 0, 8); -- Grosk
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (14139, 0, 0, 0, 27654, 0, 8); -- Booran Plainswind
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (13550, 0, 0, 0, 27654, 0, 8); -- Byula
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24774, 0, 0, 0, 27654, 0, 8); -- Kauth
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (29233, 0, 0, 0, 27654, 0, 8); -- Jayka
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (28340, 0, 0, 0, 27654, 0, 8); -- Sikewa
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (50060, 0, 0, 0, 27654, 0, 8); -- Greul
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (21575, 0, 0, 0, 27654, 0, 8); -- Abeqwa
+
+-- EK
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (80346, 0, 0, 0, 27654, 0, 8); -- Farley
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (66978, 0, 0, 0, 27654, 0, 8); -- Heather
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10076, 0, 0, 0, 27654, 0, 8); -- Brianna
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (4208, 0, 0, 0, 27654, 0, 8); -- Trelayne
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (537, 0, 0, 0, 27654, 0, 8); -- Skindle
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (8219, 0, 0, 0, 27654, 0, 8); -- Hearthstove
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (199, 0, 0, 0, 27654, 0, 8); -- Belm
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (9460, 0, 0, 0, 27654, 0, 8); -- Helbrek
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (15326, 0, 0, 0, 27654, 0, 8); -- Anderson
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (92923, 0, 0, 0, 27654, 0, 8); -- Thulfram
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (54188, 0, 0, 0, 27654, 0, 8); -- Jessica Chambers
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (28474, 0, 0, 0, 27654, 0, 8); -- Renee
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (17865, 0, 0, 0, 27654, 0, 8); -- Bates
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (15287, 0, 0, 0, 27654, 0, 8); -- Shay
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (92884, 0, 0, 0, 27654, 0, 8); -- Lard
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (11273, 0, 0, 0, 27654, 0, 8); -- Adegwa
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (6889, 0, 0, 0, 27654, 0, 8); -- Shul'kar
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (31947, 0, 0, 0, 27654, 0, 8); -- Karakul
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (690, 0, 0, 0, 27654, 0, 8); -- Thulbek
+-- Fixing Innkeepers Gossip
+
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (7057, 8319, 0, 0); -- Adding horde gossip menu for gifts gossip
+
+-- Main Menu
+-- Adjusting options to conform to 0- Trick or treat, 1- Make inn home, 2- Heart/love, 3-What can do at inn, 4- Browse goods
+-- Capitals
+UPDATE `gossip_menu_option` SET `id`= 1 WHERE `menu_id`= 342 AND `option_text`= 'Make this inn your home.'; -- Innkeeper Allison
+UPDATE `gossip_menu_option` SET `id`= 1 WHERE `menu_id`= 1290 AND `option_text`= 'Make this inn your home.'; -- Innkeeper Gryshka
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (1290, 0, 0, 'Trick or Treat!', 1, 1, 0, 0, 342, 0, 0, NULL, 164); -- missing
+UPDATE `gossip_menu_option` SET `id`= 1 WHERE `menu_id`= 1581 AND `option_text`= 'Make this inn your home.'; -- Innkeeper Saelienne
+UPDATE `gossip_menu_option` SET `id`= 1 WHERE `menu_id`= 344 AND `option_text`= 'Make this inn your home.'; -- Innkeeper Pala
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (344, 0, 0, 'Trick or Treat!', 1, 1, 0, 0, 342, 0, 0, NULL, 164); -- missing
+UPDATE `gossip_menu_option` SET `id`= 1 WHERE `menu_id`= 345 AND `option_text`= 'Make this inn your home.'; -- Innkeeper Firebrew
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (345, 0, 0, 'Trick or Treat!', 1, 1, 0, 0, 342, 0, 0, NULL, 164); -- missing
+DELETE FROM `gossip_menu_option` WHERE `menu_id`= 1296 AND `id`= 4; -- Unknown Superfluous entry_id` Innkeeper Norman
+UPDATE `gossip_menu_option` SET `id`= 4 WHERE `menu_id`= 1296 AND `option_text`= 'Let me browse your goods.';
+
+-- Kalimdor
+-- Innkeeper Keldamyr
+UPDATE `gossip_menu_option` SET `id`= 4 WHERE `menu_id`= 1293 AND `option_text`= 'I want to browse your goods.';
+UPDATE `gossip_menu_option` SET `id`= 3 WHERE `menu_id`= 1293 AND `option_text`= 'What can I do at an inn?';
+-- Innkeeper Shaussiy
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (347, 4, 1, 'I want to browse your goods.', 3, 4, 0, 0, 0, 0, 0, '', 0); -- Adding missing option
+UPDATE `gossip_menu_option` SET `id`= 3 WHERE `menu_id`= 347 AND `option_text`= 'What can I do at an inn?';
+UPDATE `gossip_menu_option` SET `id`= 0 WHERE `menu_id`= 347 AND `option_text`= 'Trick or Treat!';
+UPDATE `gossip_menu_option` SET `id`= 1 WHERE `menu_id`= 347 AND `option_text`= 'Make this inn your home.';
+
+-- Innkeeper Vizzie
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (349, 0, 0, 'Trick or Treat!', 1, 1, 0, 0, 342, 0, 0, NULL, 164); -- missing
+UPDATE `gossip_menu_option` SET `id`= 1 WHERE `menu_id`= 349 AND `option_text`= 'Make this inn your home.';
+UPDATE `gossip_menu_option` SET `id`= 4 WHERE `menu_id`= 349 AND `option_text`= 'Let me browse your goods.';
+-- Innkeeper Calandrath
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (6525, 0, 0, 'Trick or Treat!', 1, 1, 0, 0, 342, 0, 0, NULL, 164); -- missing
+UPDATE `gossip_menu_option` SET `id`= 1 WHERE `menu_id`= 6525 AND `option_text`= 'Make this inn your home.';
+UPDATE `gossip_menu_option` SET `id`= 4 WHERE `menu_id`= 6525 AND `option_text`= 'I wish to browse your wares, Calandrath.';
+-- Innkeeper Fizzgrimble
+UPDATE `gossip_menu_option` SET `id`= 4 WHERE `menu_id`= 2890 AND `option_text`= 'I want to browse your goods.';
+UPDATE `gossip_menu_option` SET `id`= 5 WHERE `menu_id`= 2890 AND `option_text`= 'GOSSIP_OPTION_QUESTGIVER';
+-- Innkeeper Kauth
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (1294, 0, 0, 'Trick or Treat!', 1, 1, 0, 0, 342, 0, 0, NULL, 164); -- missing
+UPDATE `gossip_menu_option` SET `id`= 4 WHERE `menu_id`= 1294 AND `option_text`= 'I want to browse your goods.';
+UPDATE `gossip_menu_option` SET `id`= 3 WHERE `menu_id`= 1294 AND `option_text`= 'What can I do at an inn?';
+-- EK
+-- Innkeeper Farley
+UPDATE `gossip_menu_option` SET `id`= 5 WHERE `menu_id`= 1291 AND `option_text`= 'GOSSIP_OPTION_QUESTGIVER';
+UPDATE `gossip_menu_option` SET `id`= 4 WHERE `menu_id`= 1291 AND `option_text`= 'I want to browse your goods.';
+UPDATE `gossip_menu_option` SET `id`= 3 WHERE `menu_id`= 1291 AND `option_text`= 'What can I do at an inn?';
+-- Innkeeper Hearthstove
+UPDATE `gossip_menu_option` SET `id`= 4 WHERE `menu_id`= 1297 AND `option_text`= 'Let me browse your goods.';
+UPDATE `gossip_menu_option` SET `id`= 3 WHERE `menu_id`= 1297 AND `option_text`= 'What can I do at an inn?';
+-- Jessica Chambers
+UPDATE `gossip_menu_option` SET `id`= 4 WHERE `menu_id`= 7173 AND `option_text`= 'Let me browse your goods.';
+UPDATE `gossip_menu_option` SET `id`= 3 WHERE `menu_id`= 7173 AND `option_text`= 'What can I do at an inn?';
+-- Lard
+UPDATE `gossip_menu_option` SET `id`= 4 WHERE `menu_id`= 6059 AND `option_text`= 'Let me browse your goods.';
+UPDATE `gossip_menu_option` SET `id`= 3 WHERE `menu_id`= 6059 AND `option_text`= 'What can I do at an inn?';
+-- Innkeeper Heather same gossip menu as Allison(342)
+-- Innkeeper Brianna, Trelayne, Anderson same gossip menu as Farley(1291)
+-- Innkeeper Skindle same gossip menu id as Vizzie(349)
+-- Innkeeper Belm same gossip menu id as Hearthstove(1297)
+-- Innkeeper Helbrek, Thulfram same gossip menu id as Firebrew(345)
+-- Innkeeper Renee, Bates, Shay same gossip menu id as Norman(1296)
+-- Innkeepers Kimlya, Faralia, Lyshaerya same gossip menu id as Saelienne(1581)
+-- Innkeeper Wiley same gossip menu id as Vizzie(349)
+-- Innkeeper Janene same gossip menu as Allison(342)
+-- Innkeeper Kaylisk, Grosk, Shul'kar, Karakul, Thulbek same gossip menu as Gryshka(1290)
+-- Innkeeper Booran, Byula, Sikewa, Greul, Abeqwa, Adegwa same gossip menu as Pala(344)
+
+-- Main submenu
+-- Capitals
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (342, 2, 0, 'Does that heart mean you\'re looking for love?', 1, 1, 7049, 0, 0, 0, 0, NULL, 500);
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (1290, 2, 0, 'Does that heart mean you\'re looking for love?', 1, 1, 7049, 0, 0, 0, 0, NULL, 500);
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (1581, 2, 0, 'Does that heart mean you\'re looking for love?', 1, 1, 7049, 0, 0, 0, 0, NULL, 500);
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (344, 2, 0, 'Does that heart mean you\'re looking for love?', 1, 1, 7049, 0, 0, 0, 0, NULL, 500);
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (345, 2, 0, 'Does that heart mean you\'re looking for love?', 1, 1, 7049, 0, 0, 0, 0, NULL, 500);
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (1296, 2, 0, 'Does that heart mean you\'re looking for love?', 1, 1, 7049, 0, 0, 0, 0, NULL, 500);
+--Kalimdor
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (1293, 2, 0, 'Does that heart mean you\'re looking for love?', 1, 1, 7049, 0, 0, 0, 0, NULL, 500); -- Keldamyr
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (347, 2, 0, 'Does that heart mean you\'re looking for love?', 1, 1, 7049, 0, 0, 0, 0, NULL, 500); -- Shaussiy
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (349, 2, 0, 'Does that heart mean you\'re looking for love?', 1, 1, 7049, 0, 0, 0, 0, NULL, 500); -- Vizzie
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (6525, 2, 0, 'Does that heart mean you\'re looking for love?', 1, 1, 7049, 0, 0, 0, 0, NULL, 500); -- Calandrath
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (2890, 2, 0, 'Does that heart mean you\'re looking for love?', 1, 1, 7049, 0, 0, 0, 0, NULL, 500); -- Fizzgrimble
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (1294, 2, 0, 'Does that heart mean you\'re looking for love?', 1, 1, 7049, 0, 0, 0, 0, NULL, 500); -- Kauth
+-- EK
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (1291, 2, 0, 'Does that heart mean you\'re looking for love?', 1, 1, 7049, 0, 0, 0, 0, NULL, 500); -- Farley
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (1297, 2, 0, 'Does that heart mean you\'re looking for love?', 1, 1, 7049, 0, 0, 0, 0, NULL, 500); -- Hearthstove
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (7173, 2, 0, 'Does that heart mean you\'re looking for love?', 1, 1, 7049, 0, 0, 0, 0, NULL, 500); -- Jessica Chambers
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (6059, 2, 0, 'Does that heart mean you\'re looking for love?', 1, 1, 7049, 0, 0, 0, 0, NULL, 500); -- Lard
+
+UPDATE `gossip_menu_option` SET `action_menu_id`= 7051 WHERE `menu_id`= 7049 AND `id`= 0;
+UPDATE `gossip_menu_option` SET `action_menu_id`= 7050 WHERE `menu_id`= 7049 AND `id`= 1;
+UPDATE `gossip_menu_option` SET `action_menu_id`= 7056, `condition_id`= 4 WHERE `menu_id`= 7049 AND `id`= 2;
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (7049, 3, 0, 'What can I do with these gifts?', 1, 1, 7057, 0, 0, 0, 0, NULL, 3);
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (7057, 0, 0, 'You\'re selling cologne and perfume?', 1, 1, 0, 0, 0, 0, 0, '', 0);
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (7057, 1, 0, 'What are love tokens?', 1, 1, 0, 0, 0, 0, 0, '', 0);
+
+-- Love Tokens submenu
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (7050, 1, 0, 'What can I do with these gifts?', 1, 1, 7057, 0, 0, 0, 0, NULL, 3); -- Adding Horde gossip option
+UPDATE `gossip_menu_option` SET `action_menu_id`= 7051 WHERE `menu_id`= 7050 AND `id`= 2;
+UPDATE `gossip_menu_option` SET `action_menu_id`= 7056, `condition_id`= 4 WHERE `menu_id`= 7050 AND `id`= 0; -- Alliance gossip only
+
+-- Perfume and Cologne submenu
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (7051, 1, 0, 'What can I do with these gifts?', 1, 1, 7057, 0, 0, 0, 0, NULL, 3); -- Adding Horde gossip option
+UPDATE `gossip_menu_option` SET `action_menu_id`= 7056, `condition_id`= 4 WHERE `menu_id`= 7051 AND `id`= 0;
+UPDATE `gossip_menu_option` SET `action_menu_id`= 7050 WHERE `menu_id`= 7051 AND `id`= 2;
+
+
+-- Gifts submenu
+UPDATE `gossip_menu_option` SET `action_menu_id`= 7051 WHERE `menu_id`= 7056 AND `id`= 0;
+UPDATE `gossip_menu_option` SET `action_menu_id`= 7050 WHERE `menu_id`= 7056 AND `id`= 1;
+UPDATE `gossip_menu_option` SET `action_menu_id`= 7051 WHERE `menu_id`= 7057 AND `id`= 0;
+UPDATE `gossip_menu_option` SET `action_menu_id`= 7050 WHERE `menu_id`= 7057 AND `id`= 1;

--- a/Updates/Ironforge Civilians.sql
+++ b/Updates/Ironforge Civilians.sql
@@ -1,0 +1,482 @@
+-- Adding Game event entries for each npc
+
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (122, 0, 0, 0, 27654, 0, 8); -- Myra Tyrngaarde *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (108, 0, 0, 0, 27654, 0, 8); -- John Turner *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1751, 0, 0, 0, 27654, 0, 8); -- Mangorn Flinthammer *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1755, 0, 0, 0, 27654, 0, 8); -- Raena Flinthammer *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1752, 0, 0, 0, 27654, 0, 8); -- Bromiir Ormsen *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1749, 0, 0, 0, 27654, 0, 8); -- Dinita Stonemantle *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (110, 0, 0, 0, 27654, 0, 8); -- Dolman Steelfury *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (112, 0, 0, 0, 27654, 0, 8); -- Grenil Steelfury *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (99, 0, 0, 0, 27654, 0, 8); -- Bryllia Ironband *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (98, 0, 0, 0, 27654, 0, 8); -- Fillius Fizzlespinner *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (102, 0, 0, 0, 27654, 0, 8); -- Pithwick *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (61, 0, 0, 0, 27654, 0, 8); -- Kelomir Ironhand *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (60, 0, 0, 0, 27654, 0, 8); -- Thalgus Thunderfist *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (62, 0, 0, 0, 27654, 0, 8); -- Hegnar Swiftaxe *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (86, 0, 0, 0, 27654, 0, 8); -- Brenwyn Wintersteel *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (94, 0, 0, 0, 27654, 0, 8); -- Lissyphus Finespindle *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (93, 0, 0, 0, 27654, 0, 8); -- Dolkin Craghelm *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (92, 0, 0, 0, 27654, 0, 8); -- Olthran Craghelm *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (100, 0, 0, 0, 27654, 0, 8); -- Grand Mason Marblesten *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (104, 0, 0, 0, 27654, 0, 8); -- Lyesa Steelbrow *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (103, 0, 0, 0, 27654, 0, 8); -- Jondor Steelbrow
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1746, 0, 0, 0, 27654, 0, 8); -- Barim Jurgenstaad *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1747, 0, 0, 0, 27654, 0, 8); -- Gwenna Firebrew *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1758, 0, 0, 0, 27654, 0, 8); -- Ginny Longberry *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1768, 0, 0, 0, 27654, 0, 8); -- Bimble Longberry *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1801, 0, 0, 0, 27654, 0, 8); -- Maeva Snowbraid *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1800, 0, 0, 0, 27654, 0, 8); -- Ingrys Stonebrow *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1775, 0, 0, 0, 27654, 0, 8); -- Tiza Battleforge *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1776, 0, 0, 0, 27654, 0, 8); -- Muiredon Battleforge *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1799, 0, 0, 0, 27654, 0, 8); -- Talvash del Kissel *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1764, 0, 0, 0, 27654, 0, 8); -- Tymor *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1762, 0, 0, 0, 27654, 0, 8); -- Bingus *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1761, 0, 0, 0, 27654, 0, 8); -- Harick Boulderdrum *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1787, 0, 0, 0, 27654, 0, 8); -- Tansy Puddlefizz *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1802, 0, 0, 0, 27654, 0, 8); -- Gerrig Bonegrip *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1805, 0, 0, 0, 27654, 0, 8); -- Durtham Greldon *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1689, 0, 0, 0, 27654, 0, 8); -- Hjoldir Stoneblade *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1785, 0, 0, 0, 27654, 0, 8); -- Lago Blackwrench *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1808, 0, 0, 0, 27654, 0, 8); -- Tynnus Venomsprout *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1887, 0, 0, 0, 27654, 0, 8); -- Curator Thorius *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1883, 0, 0, 0, 27654, 0, 8); -- Lyon Mountainheart *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1898, 0, 0, 0, 27654, 0, 8); -- Librarian Mae Paledust *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1896, 0, 0, 0, 27654, 0, 8); -- Prospector Stormpike *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (2005, 0, 0, 0, 27654, 0, 8); -- Historian Karnik *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (2006, 0, 0, 0, 27654, 0, 8); -- Advisor Belgrum *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1897, 0, 0, 0, 27654, 0, 8); -- Krom Stoutarm *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1884, 0, 0, 0, 27654, 0, 8); -- High Explorer Magellas *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1888, 0, 0, 0, 27654, 0, 8); -- Roetten Stonehammer *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (51, 0, 0, 0, 27654, 0, 8); -- Sognar Cliffbeard *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (56, 0, 0, 0, 27654, 0, 8); -- Sara Balloo *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (27, 0, 0, 0, 27654, 0, 8); -- Bretta Goldfury *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (39, 0, 0, 0, 27654, 0, 8); -- Skolmin Goldfury *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (53, 0, 0, 0, 27654, 0, 8); -- Bruuk Barleybeard *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (54, 0, 0, 0, 27654, 0, 8); -- Edris Barleybeard *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (28, 0, 0, 0, 27654, 0, 8); -- Soolie Berryfizz *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26, 0, 0, 0, 27654, 0, 8); -- Gnoarn *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (35, 0, 0, 0, 27654, 0, 8); -- Master Mechanic Castpipe *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (33, 0, 0, 0, 27654, 0, 8); -- Klockmort Spannerspan *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (42, 0, 0, 0, 27654, 0, 8); -- Gearcutter Cogspinner *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (40, 0, 0, 0, 27654, 0, 8); -- Lomac Gearstrip *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1816, 0, 0, 0, 27654, 0, 8); -- Sraaz *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (2014, 0, 0, 0, 27654, 0, 8); -- Thurgrum Deepforge *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1812, 0, 0, 0, 27654, 0, 8); -- Golnir Bouldertoe *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1784, 0, 0, 0, 27654, 0, 8); -- Burbik Gearspanner *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1798, 0, 0, 0, 27654, 0, 8); -- Poranna Snowbraid *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1797, 0, 0, 0, 27654, 0, 8); -- Outfitter Eric *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (2083, 0, 0, 0, 27654, 0, 8); -- Bombus Finespindle *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (95, 0, 0, 0, 27654, 0, 8); -- Gwina Stonebranch *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (48, 0, 0, 0, 27654, 0, 8); -- Tilli Thistlefuzz *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1891, 0, 0, 0, 27654, 0, 8); -- Emrul Riknussun *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (2031, 0, 0, 0, 27654, 0, 8); -- Tormus Deepforge *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1890, 0, 0, 0, 27654, 0, 8); -- Brombar Higgleby *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (91693, 0, 0, 0, 27654, 0, 8); -- Tormek Stoneriver *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (63, 0, 0, 0, 27654, 0, 8); -- Demnul Farmountain *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (2022, 0, 0, 0, 27654, 0, 8); -- Pilot Longbeard *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (2021, 0, 0, 0, 27654, 0, 8); -- Xiggs Fuselighter *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1793, 0, 0, 0, 27654, 0, 8); -- Binny Springblade *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1788, 0, 0, 0, 27654, 0, 8); -- Prynne *
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (2018, 0, 0, 0, 27654, 0, 8); -- Muren Stormpike *
+
+-- Tisa Martine (Human with IF faction)
+
+-- Gossips
+-- Dwarf Vendors
+-- Myra Tyrngaarde
+-- Adding/Removing Gossip option
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5109, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Myra');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5109, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Myra');
+UPDATE `creature_template` SET `GossipMenuId`= 12850 WHERE `Entry`= 5109;
+
+-- Dolkin Craghelm
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5125, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Dolkin');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5125, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Dolkin');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 5125;
+
+-- Olthran Craghelm
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5126, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Olthran');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5126, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Olthran');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 5121;
+
+-- Kelomir Ironhand
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5121, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Kelomir');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5121, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Kelomir');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 5121;
+
+-- Thalgus Thunderfist
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 7976, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Thalgus');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 7976, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Thalgus');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 7976;
+
+-- Brenwyn Wintersteel
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5120, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Brenwyn');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5120, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Brenwyn');
+UPDATE `creature_template` SET `GossipMenuId`= 12850 WHERE `Entry`= 5120;
+
+-- Hegnar Swiftaxe
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5119, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Hegnar');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5119, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Hegnar');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 5119;
+
+-- Bruuk Barleybeard
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5570, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Bruuk');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5570, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Bruuk');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 5570;
+
+-- Edris Barleybeard
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5140, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Edris');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5140, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Edris');
+UPDATE `creature_template` SET `GossipMenuId`= 12850 WHERE `Entry`= 5140;
+
+-- Bretta Goldfury
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5123, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Bretta');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5123, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Bretta');
+UPDATE `creature_template` SET `GossipMenuId`= 12850 WHERE `Entry`= 5123;
+
+-- Skolmin Goldfury
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5122, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Skolmin');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5122, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Skolmin');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 5122;
+
+-- Sognar Cliffbeard
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5124, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Sognar');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5124, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Sognar');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 5124;
+
+-- Bryllia Ironband
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5101, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Bryllia');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5101, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Bryllia');
+UPDATE `creature_template` SET `GossipMenuId`= 12850 WHERE `Entry`= 5101;
+
+-- Dolman Steelfury
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5102, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Dolman');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5102, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Dolman');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 5102;
+
+-- Grenil Steelfury
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5103, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Grenil');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5103, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Grenil');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 5103;
+
+-- Raena Flinthammer
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5108, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Raena');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5108, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Raena');
+UPDATE `creature_template` SET `GossipMenuId`= 12850 WHERE `Entry`= 5108;
+
+-- Mangorn Flinthammer
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5107, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Mangorn');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5107, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Mangorn');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 5107;
+
+-- Bromiir Ormsen
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5106, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Bromiir');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5106, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Bromiir');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 5106;
+
+-- Barim Jurgenstaad
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5110, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Barim');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5110, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Barim');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 5110;
+
+-- Gwenna Firebrew
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5112, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Barim');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5112, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Barim');
+UPDATE `creature_template` SET `GossipMenuId`= 12850 WHERE `Entry`= 5112;
+
+-- Harick Boulderdrum
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5133, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Harick');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5133, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Harick');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 5133;
+
+-- Maeva Snowbraid
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5156, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Maeva');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5156, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Maeva');
+UPDATE `creature_template` SET `GossipMenuId`= 12850 WHERE `Entry`= 5156;
+
+-- Ingrys Stonebrow
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5155, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Ingrys');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5155, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Ingrys');
+UPDATE `creature_template` SET `GossipMenuId`= 12850 WHERE `Entry`= 5155;
+
+-- Hjoldir Stoneblade
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5170, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Hjoldir');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5170, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Hjoldir');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 5170;
+
+-- Golnir Bouldertoe
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4256, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Golnir');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4256, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Golnir');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 4256;
+
+-- Poranna Snowbraid
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5154, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Poranna');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5154, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Poranna');
+UPDATE `creature_template` SET `GossipMenuId`= 12850 WHERE `Entry`= 5154;
+
+-- Gwina Stonebranch
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5138, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Gwina');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5138, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Gwina');
+UPDATE `creature_template` SET `GossipMenuId`= 12850 WHERE `Entry`= 5138;
+
+-- Emrul Riknussen
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5160, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Emrul');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5160, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Emrul');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 5160;
+
+-- Thurgrum Deepforge
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4259, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Thurrum');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4259, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Thurgrum');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 4259;
+
+-- Lyesa Steelbrow
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5049, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Lyesa');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5049, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Lyesa');
+UPDATE `creature_template` SET `GossipMenuId`= 12850 WHERE `Entry`= 5049;
+
+-- Dwarf Questgiver 
+-- Sara Balloo
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 2695, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Sara');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 2695, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Sara');
+UPDATE `creature_template` SET `GossipMenuId`= 12850 WHERE `Entry`= 2695;
+
+-- Tiza Battleforge
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 6179, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Tiza');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 6179, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Tiza');
+UPDATE `creature_template` SET `GossipMenuId`= 12850 WHERE `Entry`= 6179;
+
+-- Muiredon Battleforge
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 6178, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Muiredon');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 6178, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Muiredon');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 6178;
+
+-- Tymor
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 8507, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Tymor');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 8507, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Tymor');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 8507;
+
+-- Gerrig Bonegrip
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 2786, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Gerrig');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 2786, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Gerrig');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 2786;
+
+-- Durtham Greldon
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 2737, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Durtham');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 2737, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Durtham');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 2737;
+
+-- Curator Thorius
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 8256, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Thorius');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 8256, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Thorius');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 8256;
+
+-- Prospector Stormpike
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 1356, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Stormpike');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 1356, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Stormpike');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 1356;
+
+-- Krom Stoutarm
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 6294, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Krom');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 6294, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Krom');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 6294;
+
+-- Librarian Mae Paledust
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3979, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Mae');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3979, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Mae');
+UPDATE `creature_template` SET `GossipMenuId`= 12850 WHERE `Entry`= 3979;
+
+-- Historian Karnik
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 2916, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Karnik');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 2916, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Karnik');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 2916;
+
+-- Advisor Belgrum
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 2918, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Belgrum');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 2918, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Belgrum');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 2918;
+
+-- Historian Karnik
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5387, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Magellas');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5387, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Magellas');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 5387;
+
+-- Roetten Stonehammer
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5637, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Roetten');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5637, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Roetten');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 5637;
+
+-- Dinita Stonemantle
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 7292, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Dinita');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 7292, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Dinita');
+UPDATE `creature_template` SET `GossipMenuId`= 12850 WHERE `Entry`= 7292;
+
+-- Tormek Stoneriver
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 16009, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Tormek');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 16009, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Tormek');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 16009;
+
+-- Grand Mason Marblesten
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 2790, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Marblesten');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 2790, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Marblesten');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 2790;
+
+-- Pilot Longbeard
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 2092, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Longbeard');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 2092, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Longbeard');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 2092;
+
+-- Xiggs Fuselighter
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 8517, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Xiggs');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 8517, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Xiggs');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 8517;
+
+-- Muren Stormpike
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 6114, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Muren');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 6114, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Muren');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 6114;
+
+-- Dwarf Non-Vendor/Questgiver
+-- Lyon Mountainheart
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 7936, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Lyon');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 7936, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Lyon');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 7936;
+
+-- Brombar Higgleby
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3842, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Brombar');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3842, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Brombar');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 3842;
+
+-- Demnul Farmountain
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 7298, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Demnul');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 7298, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Demnul');
+UPDATE `creature_template` SET `GossipMenuId`= 12851 WHERE `Entry`= 7298;
+
+-- Gnome Vendors
+-- Fillius Fizzlespinner
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5100, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Fillius');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5100, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Fillius');
+UPDATE `creature_template` SET `GossipMenuId`= 12855 WHERE `Entry`= 5100;
+
+-- Pithwick
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5132, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Pithwick');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5132, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Pithwick');
+UPDATE `creature_template` SET `GossipMenuId`= 12855 WHERE `Entry`= 5132;
+
+-- Lissyphus Findlespinner
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5129, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Lissyphus');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5129, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Lissyphus');
+UPDATE `creature_template` SET `GossipMenuId`= 12854 WHERE `Entry`= 5129;
+
+-- Soolie Berryfizz
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5178, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Soolie');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5178, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Soolie');
+UPDATE `creature_template` SET `GossipMenuId`= 12854 WHERE `Entry`= 5178;
+
+-- Gearcutter Cogspinner
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5175, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Gearcutter');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5175, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Gearcutter');
+UPDATE `creature_template` SET `GossipMenuId`= 12855 WHERE `Entry`= 5175;
+
+-- Tynnus Venomsprout
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5169, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Tynnus');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5169, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Tynnus');
+UPDATE `creature_template` SET `GossipMenuId`= 12855 WHERE `Entry`= 5169;
+
+-- Tansy Puddlefizz
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5162, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Tansy');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5162, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Tansy');
+UPDATE `creature_template` SET `GossipMenuId`= 12854 WHERE `Entry`= 5162;
+
+-- Bimble Longberry
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 7978, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Bimble');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 7978, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Bimble');
+UPDATE `creature_template` SET `GossipMenuId`= 12854 WHERE `Entry`= 7978;
+
+-- Bingus
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5152, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Bingus');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5152, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Bingus');
+UPDATE `creature_template` SET `GossipMenuId`= 12855 WHERE `Entry`= 5152;
+
+-- Ginny Longberry
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5151, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Ginny');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5151, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Ginny');
+UPDATE `creature_template` SET `GossipMenuId`= 12854 WHERE `Entry`= 5151;
+
+-- Bombus Finespindle
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5128, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Bombus');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5128, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Bombus');
+UPDATE `creature_template` SET `GossipMenuId`= 12855 WHERE `Entry`= 5128;
+
+-- Sraaz
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 9099, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Sraaz');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 9099, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Sraaz');
+UPDATE `creature_template` SET `GossipMenuId`= 12855 WHERE `Entry`= 9099;
+
+-- Outfitter Eric
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 8681, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Eric');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 8681, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Eric');
+UPDATE `creature_template` SET `GossipMenuId`= 12855 WHERE `Entry`= 8681;
+
+-- Burbik Gearspinner
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5163, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Burbik');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5163, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Burbik');
+UPDATE `creature_template` SET `GossipMenuId`= 12855 WHERE `Entry`= 5163;
+
+-- Tilli Thistlefuzz
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5158, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Tilli');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5158, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Tilli');
+UPDATE `creature_template` SET `GossipMenuId`= 12854 WHERE `Entry`= 5158;
+
+-- Gnome Questgivers
+-- Gnoarn
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 6569, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Gnoarn');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 6569, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Gnoarn');
+UPDATE `creature_template` SET `GossipMenuId`= 12855 WHERE `Entry`= 6569;
+
+-- Lomac Gearstrip
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4081, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Lomac');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4081, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Lomac');
+UPDATE `creature_template` SET `GossipMenuId`= 12855 WHERE `Entry`= 4081;
+
+-- Master Mechanic Castpipe
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 7950, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Castpipe');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 7950, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Castpipe');
+UPDATE `creature_template` SET `GossipMenuId`= 12855 WHERE `Entry`= 7950;
+
+-- Klockmort Spannerspan
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 6169, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Klockmort');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 6169, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Klockmort');
+UPDATE `creature_template` SET `GossipMenuId`= 12855 WHERE `Entry`= 6169;
+
+-- Lago Blackwrench
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 6120, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Lago');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 6120, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Lago');
+UPDATE `creature_template` SET `GossipMenuId`= 12855 WHERE `Entry`= 6120;
+
+-- Talvash del Kissel
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 6826, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Talvash');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 6826, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Talvash');
+UPDATE `creature_template` SET `GossipMenuId`= 12855 WHERE `Entry`= 6826;
+
+-- Gnome Non-vendor/Questgiver
+
+-- Binny Springblade
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 10455, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Binny');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 10455, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Binny');
+UPDATE `creature_template` SET `GossipMenuId`= 12854 WHERE `Entry`= 10455;
+
+-- Prynne
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 10456, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Prynne');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 10456, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Prynne');
+UPDATE `creature_template` SET `GossipMenuId`= 12854 WHERE `Entry`= 10456;
+
+-- Human Non-Vendor
+-- John Turner
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 6175, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to John');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 6175, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from John');
+UPDATE `creature_template` SET `GossipMenuId`= 12863 WHERE `Entry`= 6175;
+
+-- Not civilians Tisa Martine(added 1.10.1), Myolor Sunderfury(needs gossip)
+ Deliana, Senator Bain Redstone, Royal Historian Archesonus,
+-- Ransin Donner, Garel Redrock, Courier Hammerfall, Jondor Steelbrow, Laris Geardawdle, Artillaryman Sheldonore + Trainers  can't be civilian givers - have original gossip

--- a/Updates/Ironforge Guards.sql
+++ b/Updates/Ironforge Guards.sql
@@ -1,0 +1,130 @@
+-- Ironforge Guards gossip + Menu
+
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (44, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (45, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (46, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (47, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (57, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (58, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (88, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (97, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (101, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (105, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (106, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (107, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (114, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (115, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (121, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (128, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (129, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (131, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (132, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (133, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (134, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (135, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (136, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (138, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (139, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (140, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (141, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (142, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (144, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (145, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1743, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1748, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1750, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1757, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1759, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1760, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1765, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1766, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1767, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1783, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1817, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1818, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1821, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1889, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1893, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1894, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1895, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (2009, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (2023, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (2024, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (2025, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (2027, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (2028, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (2079, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (2081, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (2085, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (2086, 0, 0, 0, 27654, 0, 8);
+
+-- Thief Catchers
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (109, 0, 0, 0, 27654, 0, 8); -- Shadowdelve
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (91, 0, 0, 0, 27654, 0, 8); -- Farmountain
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1814, 0, 0, 0, 27654, 0, 8); -- Thunderbrew
+
+
+-- Adding gossip and conditions
+
+-- IF Guards
+-- Changing standard gossip to display only outside of event
+UPDATE `gossip_menu` SET `condition_id`= 501 WHERE `entry`= 2121 and `text_id`= 2760;
+
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (2121, 8251, 0, 507);
+
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (2121, 13, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 0, 0, 0, NULL, 523);
+
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (2121, 8283, 0, 508);
+
+-- No Perfume gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (2121, 8289, 0, 520);
+
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (2121, 8296, 0, 518);
+
+-- Cast Valentine(27547) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (212101, 0, 15, 27547, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine IF Guard on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (212101, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+UPDATE `gossip_menu_option` SET `action_script_id`= 212101 WHERE `menu_id`= 2121 AND `id`= 13;
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (2121, 8291, 0, 524);
+
+
+-- Thief Catchers template - Gossip Menu + Options
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12865, 8251, 0, 507);
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12865, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 1286501, 0, 0, NULL, 523);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12865, 8283, 0, 508);
+-- No Perfume gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12865, 8289, 0, 520);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12865, 8296, 0, 518);
+-- Cast Valentine(27547) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1286501, 0, 15, 27547, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine IF Guard on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1286501, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12865, 8291, 0, 524);
+
+
+-- Thief Catcher Shadowdelve
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 14363, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Shadowdelve');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 14363, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Shadowdelve');
+UPDATE `creature_template` SET `GossipMenuId`= 12865 WHERE `Entry`= 14363;
+
+-- Thief Catcher Farmountain
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 14365, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Farmountain');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 14365, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Farmountain');
+UPDATE `creature_template` SET `GossipMenuId`= 12865 WHERE `Entry`= 14365;
+
+-- Thiefcatcher Thunderbrew
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 14367, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Thunderbrew');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 14367, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Thunderbrew');
+UPDATE `creature_template` SET `GossipMenuId`= 12865 WHERE `Entry`= 14367;

--- a/Updates/Kwee.sql
+++ b/Updates/Kwee.sql
@@ -1,0 +1,40 @@
+/* Kwee Changes */
+
+-- Correcting Gift Giving quests
+
+UPDATE `quest_template` SET `MinLevel`= 1, `QuestLevel`= 60, `RequiredRaces`= 178, `SpecialFlags`= 1, `OfferRewardText`= 'Wonderful! Wonderful! I will add this to the pile of other gifts.$B$BI didn\'t expect so many! You must truly love your leaders.$B$BNow, let me just add one more to the count...', `RequestItemsText`= 'Have you come to deliver a present of love and adoration to your favorite leader?', `CompleteEmote`= 6, `OfferRewardEmote1`= 1 WHERE `entry`= 8981;
+UPDATE `quest_template` SET `QuestLevel`= 60, `SpecialFlags`= 1 WHERE `entry`= 8993;
+
+INSERT INTO `creature_involvedrelation` (`id`, `quest`) VALUES (16075, 8981);
+INSERT INTO `creature_questrelation` (`id`, `quest`) VALUES (16075, 8981);
+
+INSERT INTO `game_event_quest` (`quest`, `event`) VALUES (8981, 8);
+INSERT INTO `game_event_quest` (`quest`, `event`) VALUES (8993, 8);
+
+-- Adding Spawns
+
+-- SW
+INSERT INTO `creature` (`guid`, `id`, `map`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecsmin`, `spawntimesecsmax`,  `spawndist`, `currentwaypoint`, `curhealth`, `curmana`, `DeathState`, `MovementType`) VALUES (91714, 16075, 0, 0, 0, -8435.320313, 321.929993, 121.746002, 2.215110, 300, 300, 0, 0, 5000, 0, 0, 0);
+INSERT INTO `game_event_creature` (`guid`, `event`) VALUES (91714, 8);
+-- IF
+INSERT INTO `creature` (`guid`, `id`, `map`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecsmin`, `spawntimesecsmax`,  `spawndist`, `currentwaypoint`, `curhealth`, `curmana`, `DeathState`, `MovementType`) VALUES (91715, 16075, 0, 0, 0, -4867.240234, -1031.479980, 502.190002, 5.384200, 300, 300, 0, 0, 5000, 0, 0, 0);
+INSERT INTO `game_event_creature` (`guid`, `event`) VALUES (91715, 8);
+-- Darn
+INSERT INTO `creature` (`guid`, `id`, `map`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecsmin`, `spawntimesecsmax`,  `spawndist`, `currentwaypoint`, `curhealth`, `curmana`, `DeathState`, `MovementType`) VALUES (91716, 16075, 1, 0, 0, 9671.019531, 2535.510010, 1360, 5.141840, 300, 300, 0, 0, 5000, 0, 0, 0);
+INSERT INTO `game_event_creature` (`guid`, `event`) VALUES (91716, 8);
+-- Org
+INSERT INTO `creature` (`guid`, `id`, `map`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecsmin`, `spawntimesecsmax`,  `spawndist`, `currentwaypoint`, `curhealth`, `curmana`, `DeathState`, `MovementType`) VALUES (91717, 16075, 1, 0, 0, 1929.651733, -4137.270508, 40.387890, 4.629610, 300, 300, 0, 0, 5000, 0, 0, 0);
+INSERT INTO `game_event_creature` (`guid`, `event`) VALUES (91717, 8);
+-- TB
+INSERT INTO `creature` (`guid`, `id`, `map`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecsmin`, `spawntimesecsmax`,  `spawndist`, `currentwaypoint`, `curhealth`, `curmana`, `DeathState`, `MovementType`) VALUES (91718, 16075, 1, 0, 0, -1196.150024, -119.406998, 163.798996, 3.086320, 300, 300, 0, 0, 5000, 0, 0, 0);
+INSERT INTO `game_event_creature` (`guid`, `event`) VALUES (91718, 8);
+-- UC
+INSERT INTO `creature` (`guid`, `id`, `map`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecsmin`, `spawntimesecsmax`,  `spawndist`, `currentwaypoint`, `curhealth`, `curmana`, `DeathState`, `MovementType`) VALUES (91719, 16075, 0, 0, 0, 1302.354004, 344.460327, -65.027145, 1.409486, 300, 300, 0, 0, 5000, 0, 0, 0);
+INSERT INTO `game_event_creature` (`guid`, `event`) VALUES (91719, 8);
+
+-- Adding /kiss buff
+UPDATE `creature_template` SET `AIName`= 'EventAI' WHERE `Entry`= 16075;
+INSERT INTO `creature_ai_scripts` (`id`, `creature_id`, `event_type`, `event_inverse_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action1_type`, `action1_param1`, `action1_param2`, `action1_param3`, `action2_type`, `action2_param1`, `action2_param2`, `action2_param3`, `action3_type`, `action3_param1`, `action3_param2`, `action3_param3`, `comment`) VALUES (1607501, 16075, 22, 0, 100, 0, 58, 0, 0, 0, 11, 27572, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Kwee Cast Smitten on receiving /kiss');
+
+
+-- Kwee Q Peddlefeet gossip + menus

--- a/Updates/Orgrimmar Civilians.sql
+++ b/Updates/Orgrimmar Civilians.sql
@@ -1,0 +1,408 @@
+-- Adding Game event entries
+
+-- Vendors
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (4654, 0, 0, 0, 27654, 0, 8); -- Shimra
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (6604, 0, 0, 0, 27654, 0, 8); -- Trak'gen
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (7442, 0, 0, 0, 27654, 0, 8); -- Horthus
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (4657, 0, 0, 0, 27654, 0, 8); -- Kaja Tau
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (706, 0, 0, 0, 27654, 0, 8); -- Barkeep Morag
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (6599, 0, 0, 0, 27654, 0, 8); -- Sana
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (6605, 0, 0, 0, 27654, 0, 8); -- Morgum
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (4652, 0, 0, 0, 27654, 0, 8); -- Ollanus
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (4658, 0, 0, 0, 27654, 0, 8); -- Olvia
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (4684, 0, 0, 0, 27654, 0, 8); -- Borstan
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (6631, 0, 0, 0, 27654, 0, 8); -- Xen'to T
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (6621, 0, 0, 0, 27654, 0, 8); -- Zeal'aya T
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (4683, 0, 0, 0, 27654, 0, 8); -- Felika
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (4679, 0, 0, 0, 27654, 0, 8); -- Kithas
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (4687, 0, 0, 0, 27654, 0, 8); -- Kor'geld
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (7478, 0, 0, 0, 27654, 0, 8); -- Handor
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (4682, 0, 0, 0, 27654, 0, 8); -- Tamar
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (6623, 0, 0, 0, 27654, 0, 8); -- Tor'phan
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (7481, 0, 0, 0, 27654, 0, 8); -- Borya
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (6628, 0, 0, 0, 27654, 0, 8); -- Gotri
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (3451, 0, 0, 0, 27654, 0, 8); -- Kareth
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (3458, 0, 0, 0, 27654, 0, 8); -- Rekkul
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (3460, 0, 0, 0, 27654, 0, 8); -- Katis
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (3455, 0, 0, 0, 27654, 0, 8); -- Muragus
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (3457, 0, 0, 0, 27654, 0, 8); -- Hagrus
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (3459, 0, 0, 0, 27654, 0, 8); -- Kor'jus
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (4666, 0, 0, 0, 27654, 0, 8); -- Asoran
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (4667, 0, 0, 0, 27654, 0, 8); -- Magenius
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (4662, 0, 0, 0, 27654, 0, 8); -- Shan'ti
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (590007, 0, 0, 0, 27654, 0, 8); -- Sergeant Ba'sha
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (3457, 0, 0, 0, 27654, 0, 8); -- Ukra'nor
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (3476, 0, 0, 0, 27654, 0, 8); -- Xan'tish T
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (6611, 0, 0, 0, 27654, 0, 8); -- Kiro
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (7451, 0, 0, 0, 27654, 0, 8); -- Jin'sora T
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (4668, 0, 0, 0, 27654, 0, 8); -- Gorina
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (7973, 0, 0, 0, 27654, 0, 8); -- Sumi
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (7453, 0, 0, 0, 27654, 0, 8); -- Zendo'jian T
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (6612, 0, 0, 0, 27654, 0, 8); -- Shoma
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (7444, 0, 0, 0, 27654, 0, 8); -- Galthuk
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (7445, 0, 0, 0, 27654, 0, 8); -- Koru
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (4674, 0, 0, 0, 27654, 0, 8); -- Shankys
+
+-- Questgivers
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (4767, 0, 0, 0, 27654, 0, 8); -- Malton Droffers
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (4766, 0, 0, 0, 27654, 0, 8); -- Dran Droffers
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (3370, 0, 0, 0, 27654, 0, 8); -- Therzok
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (6458, 0, 0, 0, 27654, 0, 8); -- Kor'ghan T
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (3419, 0, 0, 0, 27654, 0, 8); -- Cazul
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (3418, 0, 0, 0, 27654, 0, 8); -- Searn Firewarder T
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (3395, 0, 0, 0, 27654, 0, 8); -- Zor Lonetree
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (1722, 0, 0, 0, 27654, 0, 8); -- Keldran
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (4728, 0, 0, 0, 27654, 0, 8); -- Belgrom
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (4760, 0, 0, 0, 27654, 0, 8); -- Bounty Hunter Kolark
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (3426, 0, 0, 0, 27654, 0, 8); -- Rilli Greasygob G
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (3468, 0, 0, 0, 27654, 0, 8); -- Orokk Omosh
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (3428, 0, 0, 0, 27654, 0, 8); -- Krathok Moltenfist
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (3470, 0, 0, 0, 27654, 0, 8); -- Ox
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (3469, 0, 0, 0, 27654, 0, 8); -- Aturk the Anvil
+
+
+-- Non Questgiver/Vendor
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (709, 0, 0, 0, 27654, 0, 8); -- Kozish G
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (708, 0, 0, 0, 27654, 0, 8); -- Sarok
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (710, 0, 0, 0, 27654, 0, 8); -- Doyo'da T
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (711, 0, 0, 0, 27654, 0, 8); -- Goma
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (707, 0, 0, 0, 27654, 0, 8); -- Zazo
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (4769, 0, 0, 0, 27654, 0, 8); -- Grunt Mojka
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (7480, 0, 0, 0, 27654, 0, 8); -- Sarlek
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (4678, 0, 0, 0, 27654, 0, 8); -- Tamaro
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (6607, 0, 0, 0, 27654, 0, 8); -- Shim'la T
+
+
+-- Adding/Removing Gossip Options
+-- Vendors
+-- Shimra
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5817, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Shimra');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5817, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Shimra');
+UPDATE `creature_template` SET `GossipMenuId`= 12868 WHERE `Entry`= 5817;
+
+-- Trak'gen
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3313, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Trakgen');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3313, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Trakgen');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 3313;
+
+-- Horthus
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3323, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Horthus');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3323, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Horthus');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 3323;
+
+-- Kaja
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3322, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Kaja');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3322, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Kaja');
+UPDATE `creature_template` SET `GossipMenuId`= 12868 WHERE `Entry`= 3322;
+
+-- Barkeep Morag
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5611, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Morag');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5611, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Morag');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 5611;
+
+-- Sana
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3319, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Sana');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3319, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Sana');
+UPDATE `creature_template` SET `GossipMenuId`= 12868 WHERE `Entry`= 3319;
+
+-- Morgum
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3321, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Morgum');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3321, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Morgum');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 3321;
+
+-- Ollanus
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3317, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Ollanus');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3317, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Ollanus');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 3317;
+
+-- Olvia
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3312, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Olvia');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3312, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Olvia');
+UPDATE `creature_template` SET `GossipMenuId`= 12868 WHERE `Entry`= 3312;
+
+-- Borstan
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3368, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Borstan');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3368, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Borstan');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 3368;
+
+-- Xen'to
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3400, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Xento');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3400, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Xento');
+UPDATE `creature_template` SET `GossipMenuId`= 12873 WHERE `Entry`= 3400;
+
+-- Zeal'aya
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3405, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Zealaya');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3405, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Zealaya');
+UPDATE `creature_template` SET `GossipMenuId`= 12872 WHERE `Entry`= 3405;
+
+-- Felika
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3367, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Felika');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3367, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Felika');
+UPDATE `creature_template` SET `GossipMenuId`= 12868 WHERE `Entry`= 3367;
+
+-- Kithas
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3346, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Kithas');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3346, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Kithas');
+UPDATE `creature_template` SET `GossipMenuId`= 12868 WHERE `Entry`= 3346;
+
+-- Kor'geld
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3348, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Borstan');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3348, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Borstan');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 3348;
+
+-- Handor
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3316, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Handor');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3316, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Handor');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 3316;
+
+-- Tamar
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3366, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Tamar');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3366, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Tamar');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 3366;
+
+-- Tor'phan
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3315, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Torphan');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3315, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Torphan');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 3315;
+
+-- Borya
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3364, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Borya');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3364, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Borya');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 3364;
+
+-- Gotri
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3369, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Gotri');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3369, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Gotri');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 3369;
+
+-- Kareth
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3331, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Kareth');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3331, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Kareth');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 3331;
+
+-- Rekkul
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3334, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Rekkul');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3334, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Rekkul');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 3334;
+
+-- Katis
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5816, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Katis');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5816, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Katis');
+UPDATE `creature_template` SET `GossipMenuId`= 12868 WHERE `Entry`= 5816;
+
+-- Muragus
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3330, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Muragus');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3330, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Muragus');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 3330;
+
+-- Hagrus
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3335, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Hagrus');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3335, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Hagrus');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 3335;
+
+-- Kor'jus
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3329, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Korjus');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3329, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Korjus');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 3329;
+
+-- Asoran
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3350, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Asoran');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3350, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Asoran');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 3350;
+
+-- Magenius
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3351, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Magenius');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3351, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Magenius');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 3351;
+
+-- Shan'ti
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3342, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Shanti');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3342, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Shanti');
+UPDATE `creature_template` SET `GossipMenuId`= 12868 WHERE `Entry`= 3342;
+
+-- Sergeant Ba'sha
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 12799, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Basha');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 12799, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Basha');
+UPDATE `creature_template` SET `GossipMenuId`= 12868 WHERE `Entry`= 12799;
+
+-- Ukra'nor
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3349, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Ukranor');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3349, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Ukranor');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 3349;
+
+-- Xan'tish
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 8404, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Xantish');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 8404, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Xantish');
+UPDATE `creature_template` SET `GossipMenuId`= 12873 WHERE `Entry`= 8404;
+
+-- Kiro
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3359, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Kiro');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3359, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Kiro');
+UPDATE `creature_template` SET `GossipMenuId`= 12868 WHERE `Entry`= 3359;
+
+-- Jin'sora
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3410, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Jinsora');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3410, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Jinsora');
+UPDATE `creature_template` SET `GossipMenuId`= 12873 WHERE `Entry`= 3410;
+
+-- Gorina
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3358, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Gorina');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3358, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Gorina');
+UPDATE `creature_template` SET `GossipMenuId`= 12868 WHERE `Entry`= 3358;
+
+-- Sumi
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3356, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Sumi');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3356, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Sumi');
+UPDATE `creature_template` SET `GossipMenuId`= 12868 WHERE `Entry`= 3356;
+
+-- Zendo'jian
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3409, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Zendojian');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3409, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Zendojian');
+UPDATE `creature_template` SET `GossipMenuId`= 12873 WHERE `Entry`= 3409;
+
+-- Shoma
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3361, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Shoma');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3361, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Shoma');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 3361;
+
+-- Galthuk
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4043, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Galthuk');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4043, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Galthuk');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 4043;
+
+-- Koru
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3360, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Koru');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3360, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Koru');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 3360;
+
+-- Shankys
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3333, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Shankys');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3333, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Shankys');
+UPDATE `creature_template` SET `GossipMenuId`= 12868 WHERE `Entry`= 3333;
+
+-- Questgivers
+-- Malton Droffers
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 6987, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Malton Droffers');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 6987, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Malton Droffes');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 6987;
+
+-- Dran Droffers
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 6986, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Dran Droffers');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 6986, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Dran Droffers');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 6986;
+
+-- Therzok
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 6446, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Therzok');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 6446, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Therzok');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 6446;
+
+-- Kor'ghan
+UPDATE `creature_template` SET `NPCFlags`= 2 WHERE `Entry`= 3189; -- NPC Gossip mistakenly set or missing gossip text?  Assuming former
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3189, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Therzok');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3189, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Therzok');
+UPDATE `creature_template` SET `GossipMenuId`= 12873 WHERE `Entry`= 3189;
+
+-- Cazul
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5909, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Cazul');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5909, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Cazul');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 5909;
+
+-- Searn Firewarder
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5892, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Searn');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5892, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Searn');
+UPDATE `creature_template` SET `GossipMenuId`= 12873 WHERE `Entry`= 5892;
+
+-- Zor Lonetree
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4047, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Zor');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4047, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Zor');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 4047;
+
+-- Keldran
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5640, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Keldran');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5640, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Keldran');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 5640;
+
+-- Belgrom Rockmaul
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4485, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Belgrom');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4485, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Belgrom');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 4485;
+
+-- Bounty Hunter Kolark
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 14182, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Kolark');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 14182, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Kolark');
+UPDATE `creature_template` SET `GossipMenuId`= 12857 WHERE `Entry`= 14182;
+
+-- Rilli Greasygob
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 9317, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Greasygob');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 9317, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Greasygob');
+UPDATE `creature_template` SET `GossipMenuId`= 12873 WHERE `Entry`= 9317;
+
+-- Orokk Omosh
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 7790, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Orokk');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 7790, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Orokk');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 7790;
+
+-- Krathok Moltenfist
+UPDATE `creature_template` SET `NPCFlags`= 2 WHERE `Entry`= 11176; -- NPC Gossip mistakenly set or missing gossip text?  Assuming former
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 11176, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Krathok');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 11176, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Krathok');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 11176;
+
+-- Ox
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 7793, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Ox');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 7793, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Ox');
+UPDATE `creature_template` SET `GossipMenuId`= 12857 WHERE `Entry`= 7793;
+
+-- Aturk the Anvil
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 7792, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Aturk');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 7792, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Aturk');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 7792;
+
+-- Non Questgiver/Vendor
+-- Kozish
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5610, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Kozish');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5610, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Kozish');
+UPDATE `creature_template` SET `GossipMenuId`= 12873 WHERE `Entry`= 5610;
+
+-- Sarok
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5614, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Sarok');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5614, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Sarok');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 5614;
+
+-- Doyo'da
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5613, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Doyoda');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5613, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Doyoda');
+UPDATE `creature_template` SET `GossipMenuId`= 12873 WHERE `Entry`= 5613;
+
+-- Goma
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5606, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Goma');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5606, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Goma');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 5606;
+
+-- Zazo
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5609, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Zazo');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5609, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Zazo');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 5609;
+
+-- Grunt Mojka
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5603, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Mojka');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5603, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Mojka');
+UPDATE `creature_template` SET `GossipMenuId`= 12868 WHERE `Entry`= 5603;
+
+-- Sarlek
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3372, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Sarlek');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3372, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Sarlek');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 3372;
+
+-- Tamaro
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3371, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Tamaro');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3371, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Tamaro');
+UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 3371;
+
+-- Shim'la
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 7294, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Shimla');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 7294, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Shimla');
+UPDATE `creature_template` SET `GossipMenuId`= 12872 WHERE `Entry`= 7294;
+
+-- Urtrun Clanbringer, Garyl, Urtharo, Zilzibin Drumlore, Jes'rimon, Rashona Straglash, Zando'zan, Gan'rul Bloodeye, Neeru Fireblade, Mokvar, Eitrigg, Vehena, Warcaller Gorlach, Sovik, Orphan Matron Battlewail, Ogunaro Wolfrunner have specific gossip
+-- Nazgrel (faction 1074), Zankaja (faction 83), Stone Guard Zarg, Brave Stonehide, Raider Bork, Legonnaire Teena(faction 85)

--- a/Updates/Orgrimmar Civilians.sql
+++ b/Updates/Orgrimmar Civilians.sql
@@ -72,6 +72,10 @@ INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipmen
 INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (4678, 0, 0, 0, 27654, 0, 8); -- Tamaro
 INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (6607, 0, 0, 0, 27654, 0, 8); -- Shim'la T
 
+-- Adding text entries for Troll and Goblin default valentine gossip
+INSERT INTO `npc_text` (`ID`, `text0_0`, `text0_1`, `lang0`, `prob0`, `em0_0`, `em0_1`, `em0_2`, `em0_3`, `em0_4`, `em0_5`, `text1_0`, `text1_1`, `lang1`, `prob1`, `em1_0`, `em1_1`, `em1_2`, `em1_3`, `em1_4`, `em1_5`, `text2_0`, `text2_1`, `lang2`, `prob2`, `em2_0`, `em2_1`, `em2_2`, `em2_3`, `em2_4`, `em2_5`, `text3_0`, `text3_1`, `lang3`, `prob3`, `em3_0`, `em3_1`, `em3_2`, `em3_3`, `em3_4`, `em3_5`, `text4_0`, `text4_1`, `lang4`, `prob4`, `em4_0`, `em4_1`, `em4_2`, `em4_3`, `em4_4`, `em4_5`, `text5_0`, `text5_1`, `lang5`, `prob5`, `em5_0`, `em5_1`, `em5_2`, `em5_3`, `em5_4`, `em5_5`, `text6_0`, `text6_1`, `lang6`, `prob6`, `em6_0`, `em6_1`, `em6_2`, `em6_3`, `em6_4`, `em6_5`, `text7_0`, `text7_1`, `lang7`, `prob7`, `em7_0`, `em7_1`, `em7_2`, `em7_3`, `em7_4`, `em7_5`) VALUES (8310, 'It has been years since I have thought with my heart, but it\'s all flooding back.', 'It has been years since I have thought with my heart, but it\'s all flooding back.', 0, 1, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0); -- Troll
+INSERT INTO `npc_text` (`ID`, `text0_0`, `text0_1`, `lang0`, `prob0`, `em0_0`, `em0_1`, `em0_2`, `em0_3`, `em0_4`, `em0_5`, `text1_0`, `text1_1`, `lang1`, `prob1`, `em1_0`, `em1_1`, `em1_2`, `em1_3`, `em1_4`, `em1_5`, `text2_0`, `text2_1`, `lang2`, `prob2`, `em2_0`, `em2_1`, `em2_2`, `em2_3`, `em2_4`, `em2_5`, `text3_0`, `text3_1`, `lang3`, `prob3`, `em3_0`, `em3_1`, `em3_2`, `em3_3`, `em3_4`, `em3_5`, `text4_0`, `text4_1`, `lang4`, `prob4`, `em4_0`, `em4_1`, `em4_2`, `em4_3`, `em4_4`, `em4_5`, `text5_0`, `text5_1`, `lang5`, `prob5`, `em5_0`, `em5_1`, `em5_2`, `em5_3`, `em5_4`, `em5_5`, `text6_0`, `text6_1`, `lang6`, `prob6`, `em6_0`, `em6_1`, `em6_2`, `em6_3`, `em6_4`, `em6_5`, `text7_0`, `text7_1`, `lang7`, `prob7`, `em7_0`, `em7_1`, `em7_2`, `em7_3`, `em7_4`, `em7_5`) VALUES (8311, 'After all these years of fighting, now everyone\'s falling in love!', 'After all these years of fighting, now everyone\'s falling in love!', 0, 1, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0); -- Goblin
+
 
 -- Adding/Removing Gossip Options
 -- Vendors
@@ -335,7 +339,7 @@ UPDATE `creature_template` SET `GossipMenuId`= 12857 WHERE `Entry`= 14182;
 -- Rilli Greasygob
 INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 9317, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Greasygob');
 INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 9317, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Greasygob');
-UPDATE `creature_template` SET `GossipMenuId`= 12873 WHERE `Entry`= 9317;
+UPDATE `creature_template` SET `GossipMenuId`= 12875 WHERE `Entry`= 9317;
 
 -- Orokk Omosh
 INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 7790, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Orokk');
@@ -362,7 +366,7 @@ UPDATE `creature_template` SET `GossipMenuId`= 12869 WHERE `Entry`= 7792;
 -- Kozish
 INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5610, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Kozish');
 INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5610, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Kozish');
-UPDATE `creature_template` SET `GossipMenuId`= 12873 WHERE `Entry`= 5610;
+UPDATE `creature_template` SET `GossipMenuId`= 12875 WHERE `Entry`= 5610;
 
 -- Sarok
 INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5614, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Sarok');

--- a/Updates/Orgrimmar Grunts.sql
+++ b/Updates/Orgrimmar Grunts.sql
@@ -1,0 +1,169 @@
+-- Adding Love is in the Air aura
+
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (3382, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (3383, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (3384, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (3385, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (3386, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (3387, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (3388, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (3389, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (3390, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (3391, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (3462, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (3465, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (6558, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (6559, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (6560, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (6561, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (6562, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (6563, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (6564, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (6565, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (6566, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (6567, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (7397, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (7398, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (7399, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (7415, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (7416, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (7417, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (7418, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (7419, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (7420, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (7421, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (7941, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (7942, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (7943, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (7945, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (7946, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (7948, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (7949, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (7950, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (8521, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (8522, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (8523, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (8524, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (8525, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (8526, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (8527, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (8528, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (8529, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (8530, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10297, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10298, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10299, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10347, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10348, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10350, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10351, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10352, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10353, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10450, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10462, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10463, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10464, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10465, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10466, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10467, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10468, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10469, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10470, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (11789, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (11790, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (11791, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (11792, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (11793, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (11794, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (11795, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (11796, 0, 0, 0, 27654, 0, 8);
+
+-- Scouts
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (6496, 0, 0, 0, 27654, 0, 8); -- Stronghand
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (6495, 0, 0, 0, 27654, 0, 8); -- Manslayer
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (6494, 0, 0, 0, 27654, 0, 8); -- Tharr
+
+-- Adding Gossip options to turn on during event and off after
+
+-- Scout Manslayer - Gossip Menu + Options
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12870, 8265, 0, 507);
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12870, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 1287001, 0, 0, NULL, 517);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12870, 8283, 0, 508);
+-- No Cologne gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12870, 8287, 0, 519);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12870, 8296, 0, 518);
+-- Cast Valentine(26663) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1287001, 0, 15, 26663, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Org Grunt on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1287001, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12870, 8291, 0, 524);
+
+-- Scout Stronghand + Tharr template - Gossip Menu + Options
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12871, 8265, 0, 507);
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12871, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 1287101, 0, 0, NULL, 523);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12871, 8283, 0, 508);
+-- No Perfume gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12871, 8289, 0, 520);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12871, 8296, 0, 518);
+-- Cast Valentine(26663) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1287101, 0, 15, 26663, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Org Grunt on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1287101, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12871, 8291, 0, 524);
+
+
+-- Scout Stronghand
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 14375, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Stronghand');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 14375, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Stronghand');
+UPDATE `creature_template` SET `GossipMenuId`= 12871 WHERE `Entry`= 14375;
+
+-- Scout Manslayer
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 14376, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Manslayer');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 14376, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Manslayer');
+UPDATE `creature_template` SET `GossipMenuId`= 12870 WHERE `Entry`= 14376;
+-- Scout Tharr
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 14377, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Tharr');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 14377, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Tharr');
+UPDATE `creature_template` SET `GossipMenuId`= 12871 WHERE `Entry`= 14377;
+
+/* Handled in SD2
+
+-- Orgrimmar Grunt gossip + menu
+-- Changing standard gossip to display only outside of event
+UPDATE `gossip_menu` SET `condition_id`= 501 WHERE `entry`= 1951 and `text_id`= 2593;
+
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (1951, 8265, 0, 507);
+
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (1951, 14, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 0, 0, 0, NULL, 528);
+
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (1951, 8282, 0, 508);
+
+-- No Perfume or Cologne gossip (Change/Remove this when gender check implemented)
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (1951, 8303, 0, 530);
+
+-- Cast Valentine(26663) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (195101, 0, 15, 26663, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Orgrimmar Grunt on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (195101, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (1951, 8296, 0, 518);
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (1951, 8291, 0, 524);
+
+UPDATE `gossip_menu_option` SET `action_script_id`= 195101 WHERE `menu_id`= 1951 AND `id`= 14;
+
+*/

--- a/Updates/Orgrimmar Grunts.sql
+++ b/Updates/Orgrimmar Grunts.sql
@@ -136,7 +136,6 @@ INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalon
 INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 14377, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Tharr');
 UPDATE `creature_template` SET `GossipMenuId`= 12871 WHERE `Entry`= 14377;
 
-/* Handled in SD2
 
 -- Orgrimmar Grunt gossip + menu
 -- Changing standard gossip to display only outside of event
@@ -146,13 +145,17 @@ UPDATE `gossip_menu` SET `condition_id`= 501 WHERE `entry`= 1951 and `text_id`= 
 INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (1951, 8265, 0, 507);
 
 -- Adding token menu option
-INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (1951, 14, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 0, 0, 0, NULL, 528);
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (1951, 14, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 195101, 0, 0, NULL, 538);
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (1951, 15, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 195101, 0, 0, NULL, 539);
 
 -- Heartbroken gossip
 INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (1951, 8282, 0, 508);
 
--- No Perfume or Cologne gossip (Change/Remove this when gender check implemented)
-INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (1951, 8303, 0, 530);
+-- No Cologne gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (1951, 8287, 0, 541);
+
+-- No Perfume gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (1951, 8289, 0, 542);
 
 -- Cast Valentine(26663) in response to receiving love token
 INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (195101, 0, 15, 26663, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Orgrimmar Grunt on player');
@@ -164,6 +167,4 @@ INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALU
 -- No Token Gossip
 INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (1951, 8291, 0, 524);
 
-UPDATE `gossip_menu_option` SET `action_script_id`= 195101 WHERE `menu_id`= 1951 AND `id`= 14;
 
-*/

--- a/Updates/Pledges and Gifts.sql
+++ b/Updates/Pledges and Gifts.sql
@@ -1,0 +1,89 @@
+-- ***************************************************************************************************
+-- *                         Pledges and Gifts                                                       *
+-- ***************************************************************************************************
+-- Pledge of Adoration (SW)
+-- Changing loot groups to reflect live
+UPDATE `item_loot_template` SET `groupid`= 2 WHERE `entry`= 21975 AND `item` IN (21812, 21813, 22218, 22235, 22261, 22279);
+UPDATE `item_loot_template` SET `groupid`= 1 WHERE `entry`= 21975 AND `item`= 22259;
+UPDATE `item_loot_template` SET `ChanceOrQuestChance`= 50 WHERE `entry`= 21975 AND `item`= 22117;
+INSERT INTO `item_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`) VALUES (21975, 22143, 50, 0, 1, 1, 0);
+INSERT INTO `item_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`) VALUES (21975, 22200, 14.0, 2, 1, 1, 0);
+
+-- Pledge of Friendship(SW)
+INSERT INTO `item_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`) VALUES (22178, 22143, 50, 0, 1, 1, 0);
+UPDATE `item_loot_template` SET `ChanceOrQuestChance`= 50 WHERE `entry`= 22178 AND `item`= 22117;
+
+-- Pledge of Adoration(Darnassus)
+UPDATE `item_loot_template` SET `groupid`= 2 WHERE `entry`= 22155 AND `item` IN (21812, 21813, 22218, 22261, 22279);
+UPDATE `item_loot_template` SET `groupid`= 1 WHERE `entry`= 22155 AND `item`= 22259;
+INSERT INTO `item_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`) VALUES (22155, 22140, 50, 0, 1, 1, 0);
+INSERT INTO `item_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`) VALUES (22155, 22200, 14.0, 2, 1, 1, 0);
+INSERT INTO `item_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`) VALUES (22155, 22235, 1.8, 2, 1, 1, 0);
+UPDATE `item_loot_template` SET `ChanceOrQuestChance`= 50 WHERE `entry`= 22155 AND `item`= 22120;
+
+-- Pledge of Friendship(Darnassus)
+INSERT INTO `item_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`) VALUES (22159, 22140, 50, 0, 1, 1, 0);
+UPDATE `item_loot_template` SET `ChanceOrQuestChance`= 50 WHERE `entry`= 22159 AND `item`= 22120;
+
+-- Pledge of Adoration(Ironforge)
+UPDATE `item_loot_template` SET `groupid`= 2 WHERE `entry`= 22154 AND `item` IN (21812, 21813, 22218, 22235, 22261, 22279);
+UPDATE `item_loot_template` SET `groupid`= 1 WHERE `entry`= 22154 AND `item`= 22259;
+INSERT INTO `item_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`) VALUES (22154, 22141, 50, 0, 1, 1, 0);
+INSERT INTO `item_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`) VALUES (22154, 22200, 14.0, 2, 1, 1, 0);
+UPDATE `item_loot_template` SET `ChanceOrQuestChance`= 50 WHERE `entry`= 22154 AND `item`= 22119;
+
+-- Pledge of Friendship(Ironforge)
+INSERT INTO `item_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`) VALUES (22160, 22141, 50, 0, 1, 1, 0);
+UPDATE `item_loot_template` SET `ChanceOrQuestChance`= 50 WHERE `entry`= 22160 AND `item`= 22119;
+
+-- Gift of Adoration(Ironforge)
+UPDATE `item_loot_template` SET `ChanceOrQuestChance`= 100 WHERE `entry`= 21980 AND `item`= 22173;
+UPDATE `item_loot_template` SET `groupid`= 1 WHERE `entry`= 21980 AND `item` IN (21812, 21813, 22218, 22235, 22259, 22261, 22279);
+INSERT INTO `item_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`) VALUES (21980, 22200, 14.0, 1, 1, 1, 0);
+
+-- Gift of Adoration(SW)
+UPDATE `item_loot_template` SET `ChanceOrQuestChance`= 100 WHERE `entry`= 21981 AND `item`= 22176;
+UPDATE `item_loot_template` SET `groupid`= 1 WHERE `entry`= 21981 AND `item` IN (21812, 21813, 22218, 22235, 22259, 22261, 22279);
+INSERT INTO `item_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`) VALUES (21981, 22200, 14.0, 1, 1, 1, 0);
+
+
+-- Gift of Adoration(Darnassus)
+UPDATE `item_loot_template` SET `ChanceOrQuestChance`= 100 WHERE `entry`= 21979 AND `item`= 21960;
+UPDATE `item_loot_template` SET `groupid`= 1 WHERE `entry`= 21979 AND `item` IN (21812, 21813, 22218, 22259, 22261, 22279);
+INSERT INTO `item_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`) VALUES (21979, 22200, 14.0, 1, 1, 1, 0);
+INSERT INTO `item_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`) VALUES (21979, 22235, 1.9, 1, 1, 1, 0);
+
+-- Pledge of Adoration(Orgrimmar)
+UPDATE `item_loot_template` SET `groupid`= 2 WHERE `entry`= 22156 AND `item` IN (21812, 21813, 22218, 22235, 22261, 22279);
+UPDATE `item_loot_template` SET `groupid`= 1 WHERE `entry`= 22156 AND `item`= 22259;
+INSERT INTO `item_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`) VALUES (22156, 22142, 50, 0, 1, 1, 0);
+INSERT INTO `item_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`) VALUES (22156, 22200, 14.0, 2, 1, 1, 0);
+UPDATE `item_loot_template` SET `ChanceOrQuestChance`= 50 WHERE `entry`= 22156 AND `item`= 22123;
+
+-- Pledge of Adoration(Undercity)
+UPDATE `item_loot_template` SET `groupid`= 2 WHERE `entry`= 22157 AND `item` IN (21812, 21813, 22218, 22235, 22261, 22279);
+UPDATE `item_loot_template` SET `groupid`= 1 WHERE `entry`= 22157 AND `item`= 22259;
+INSERT INTO `item_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`) VALUES (22157, 22145, 50, 0, 1, 1, 0);
+INSERT INTO `item_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`) VALUES (22157, 22200, 14.0, 2, 1, 1, 0);
+UPDATE `item_loot_template` SET `ChanceOrQuestChance`= 50 WHERE `entry`= 22157 AND `item`= 22121;
+
+-- Pledge of Adoration(Thunder Bluff)
+UPDATE `item_loot_template` SET `groupid`= 2 WHERE `entry`= 22158 AND `item` IN (21812, 21813, 22218, 22261, 22279);
+UPDATE `item_loot_template` SET `groupid`= 1 WHERE `entry`= 22158 AND `item`= 22259;
+INSERT INTO `item_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`) VALUES (22158, 22144, 50, 0, 1, 1, 0);
+INSERT INTO `item_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`) VALUES (22158, 22200, 14.0, 2, 1, 1, 0);
+INSERT INTO `item_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`) VALUES (22158, 22235, 1.8, 2, 1, 1, 0);
+UPDATE `item_loot_template` SET `ChanceOrQuestChance`= 50 WHERE `entry`= 22158 AND `item`= 22122;
+
+-- Pledge of Friendship(Orgrimmar)
+INSERT INTO `item_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`) VALUES (22161, 22142, 50, 0, 1, 1, 0);
+UPDATE `item_loot_template` SET `ChanceOrQuestChance`= 50 WHERE `entry`= 22161 AND `item`= 22123;
+
+-- Pledge of Friendship(Thunder Bluff)
+INSERT INTO `item_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`) VALUES (22162, 22144, 50, 0, 1, 1, 0);
+UPDATE `item_loot_template` SET `ChanceOrQuestChance`= 50 WHERE `entry`= 22162 AND `item`= 22122;
+
+-- Pledge of Friendship(Undercity)
+INSERT INTO `item_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`) VALUES (22163, 22145, 50, 0, 1, 1, 0);
+UPDATE `item_loot_template` SET `ChanceOrQuestChance`= 50 WHERE `entry`= 22163 AND `item`= 22121;
+

--- a/Updates/Quests.sql
+++ b/Updates/Quests.sql
@@ -1,0 +1,72 @@
+/* Adding Exclusive Group to ensure only one Dearest Colara is chosen and completed + NextQuestId to ensure Dangerous is available only after completion of one of them */
+
+UPDATE `quest_template` SET `MinLevel`= 1, `QuestLevel`= 60, `NextQuestId`= 8903,`ExclusiveGroup`= 8897 WHERE `entry` IN (8897, 8898, 8899);
+
+
+/* Adding Exclusive Group to ensure only one Dearest Elenia is chosen and completed + NextQuestId to ensure Dangerous is available only after completion of one of them*/
+
+UPDATE `quest_template` SET `MinLevel`= 1, `QuestLevel`= 60, `NextQuestId`= 8904, `ExclusiveGroup`= 8900 WHERE `entry` IN (8900, 8901, 8902);
+
+-- Fixing a few errors
+UPDATE `quest_template` SET `MinLevel`= 1,`QuestLevel`= 60 WHERE `entry`= 8903;
+UPDATE `quest_template` SET `QuestLevel`= 60, `RequiredRaces`= 178 WHERE `entry`= 8904;
+
+/* Adding entries to adjust Dangerous Love questline */
+-- Alliance
+UPDATE `quest_template` SET `MinLevel`= 1, `QuestLevel`= 60, `PrevQuestId`= 8903 WHERE `entry`= 9024; -- Aristan's Hunch
+UPDATE `quest_template` SET `MinLevel`= 1, `QuestLevel`= 60, `PrevQuestId`= 9024 WHERE `entry`= 9025; -- Morgan's Discovery
+UPDATE `quest_template` SET `MinLevel`= 1, `QuestLevel`= 60, `PrevQuestId`= 9025 WHERE `entry`= 9026; -- Tracing the Source(1)
+UPDATE `quest_template` SET `MinLevel`= 1, `QuestLevel`= 60, `PrevQuestId`= 9026 WHERE `entry`= 9027; -- Tracing the Source(2)
+UPDATE `quest_template` SET `MinLevel`= 1, `QuestLevel`= 60, `PrevQuestId`= 9027 WHERE `entry`= 9028; -- The Sourced Revealed
+
+-- Horde
+UPDATE `quest_template` SET `MinLevel`= 1, `QuestLevel`= 60, `PrevQuestId`= 8904 WHERE `entry`= 8979; -- Fenstad's Hunch
+UPDATE `quest_template` SET `MinLevel`= 1, `QuestLevel`= 60, `PrevQuestId`= 8979 WHERE `entry`= 8980; -- Zinge's Assessment
+UPDATE `quest_template` SET `MinLevel`= 1, `QuestLevel`= 60, `PrevQuestId`= 8980 WHERE `entry`= 8982; -- Tracing the Source(1)
+UPDATE `quest_template` SET `MinLevel`= 1, `QuestLevel`= 60, `PrevQuestId`= 8982 WHERE `entry`= 8983; -- Tracing the Source(2)
+UPDATE `quest_template` SET `MinLevel`= 1, `QuestLevel`= 60, `PrevQuestId`= 8983 WHERE `entry`= 8984; -- The Sourced Revealed
+
+-- Common
+UPDATE `quest_template` SET `PrevQuestId`= 9028 WHERE `entry`= 9029; -- The Bubbling Cauldron
+
+/* Adding db acript string entries for Lerent discourse */
+
+INSERT INTO `dbscript_string` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`, `sound`, `type`, `language`, `emote`, `comment`) VALUES (2000000200, 'Staffron...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 1, 'Annalise Dialogue 1');
+INSERT INTO `dbscript_string` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`, `sound`, `type`, `language`, `emote`, `comment`) VALUES (2000000201, 'Annalise? Is that you?', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 1, 'Staffron Dialogue 1');
+INSERT INTO `dbscript_string` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`, `sound`, `type`, `language`, `emote`, `comment`) VALUES (2000000202, 'My dear Staffron, have you forgotten what it is to love? The love that we once shared?', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 1, 'Annalise Dialogue 2');
+INSERT INTO `dbscript_string` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`, `sound`, `type`, `language`, `emote`, `comment`) VALUES (2000000203, 'Have I forgotten? Of course I have... I have forgotten about love, happiness... of life itself.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 1, 'Staffron Dialogue 2');
+INSERT INTO `dbscript_string` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`, `sound`, `type`, `language`, `emote`, `comment`) VALUES (2000000204, 'But i do know this - love makes the heart and body weak. It can be exploited. Without your love, I have only my work, Annalise.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 1, 'Staffron Dialogue 3');
+INSERT INTO `dbscript_string` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`, `sound`, `type`, `language`, `emote`, `comment`) VALUES (2000000205, 'But of course I love you, Staffron. And it pains me to see you suffer so.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 1, 'Annalise Dialogue 3');
+INSERT INTO `dbscript_string` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`, `sound`, `type`, `language`, `emote`, `comment`) VALUES (2000000206, 'I pledge my love to you forever. Death cannot erase that, even as I am sure that you still remember your love for me.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 1, 'Annalise Dialogue 4');
+INSERT INTO `dbscript_string` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`, `sound`, `type`, `language`, `emote`, `comment`) VALUES (2000000207, 'And if you do not, then I am truly lost.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 1, 'Annalise Dialogue 5');
+INSERT INTO `dbscript_string` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`, `sound`, `type`, `language`, `emote`, `comment`) VALUES (2000000208, 'How could you love me, Annalise? Look at me. I am not the man you once knew.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 1, 'Staffron Dialogue 4');
+INSERT INTO `dbscript_string` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`, `sound`, `type`, `language`, `emote`, `comment`) VALUES (2000000209, 'Annalise? Annalise! No, don\'t leave me!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 1, 'Staffron Dialogue 5');
+INSERT INTO `dbscript_string` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`, `sound`, `type`, `language`, `emote`, `comment`) VALUES (2000000210, 'Annalise... You\'re right. I-I can\'t do this. I must find another way.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 1, 'Staffron Dialogue 6');
+INSERT INTO `dbscript_string` (`entry`, `content_default`, `content_loc1`, `content_loc2`, `content_loc3`, `content_loc4`, `content_loc5`, `content_loc6`, `content_loc7`, `content_loc8`, `sound`, `type`, `language`, `emote`, `comment`) VALUES (2000000211, 'You there. You\'re welcome to take the contents of my cauldron. It was to be the second stage of my plan - amorous clothing.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 1, 'Staffron Dialogue 7');
+
+/* Dbscript entries triggered by completion of The Source Revealed */
+
+UPDATE `quest_template` SET `CompleteScript`= 9029 WHERE `entry` IN (8984, 9028);
+
+/* Adding WP Movement and 1 WP Annalise and Staffron*/
+
+UPDATE `creature_template` SET `MovementType`= 2 WHERE `Entry`IN (16107, 16110);
+
+INSERT INTO `creature_movement_template` (`entry`, `point`, `position_x`, `position_y`, `position_z`, `waittime`, `script_id`, `textid1`, `textid2`, `textid3`, `textid4`, `textid5`, `emote`, `spell`, `orientation`, `model1`, `model2`) VALUES (16110, 1, 95.655884, -1713.355347, 220.825989, 70000, 1611001, 0, 0, 0, 0, 0, 0, 0, 4.267725, 0, 0);
+UPDATE `creature` SET `MovementType`= 2 WHERE `id`= 16107;
+
+INSERT INTO `dbscripts_on_quest_end` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (9029, 2, 10, 16110, 40000, 0, 0, 0, 0, 0, 0, 0, 95.655884, -1713.355347, 220.825989, 4.267725, 'Summon Annalise Lerent');
+INSERT INTO `dbscripts_on_quest_end` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (9029, 5, 0, 0, 0, 16110, 10, 0, 2000000200, 0, 0, 0, 0, 0, 0, 0, 'Annalise Dialogue 1');
+INSERT INTO `dbscripts_on_quest_end` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (9029, 9, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  1.024037, 'Staffron Turns to Annalise');
+INSERT INTO `dbscripts_on_quest_end` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (9029, 13, 0, 0, 0, 0, 0, 0, 2000000201, 0, 0, 0, 0, 0, 0, 0, 'Staffron Dialogue 1');
+INSERT INTO `dbscripts_on_quest_end` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (9029, 17, 0, 0, 0, 16110, 10, 0, 2000000202, 0, 0, 0, 0, 0, 0, 0, 'Annalise Dialogue 2');
+INSERT INTO `dbscripts_on_quest_end` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (9029, 21, 0, 0, 0, 0, 0, 0, 2000000203, 0, 0, 0, 0, 0, 0, 0, 'Staffron Dialogue 2');
+INSERT INTO `dbscripts_on_quest_end` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (9029, 25, 0, 0, 0, 0, 0, 0, 2000000204, 0, 0, 0, 0, 0, 0, 0, 'Staffron Dialogue 3');
+INSERT INTO `dbscripts_on_quest_end` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (9029, 29, 0, 0, 0, 16110, 10, 0, 2000000205, 0, 0, 0, 0, 0, 0, 0, 'Annalise Dialogue 3');
+INSERT INTO `dbscripts_on_quest_end` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (9029, 33, 0, 0, 0, 16110, 10, 0, 2000000206, 0, 0, 0, 0, 0, 0, 0, 'Annalise Dialogue 4');
+INSERT INTO `dbscripts_on_quest_end` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (9029, 37, 0, 0, 0, 16110, 10, 0, 2000000207, 0, 0, 0, 0, 0, 0, 0, 'Annalise Dialogue 5');
+INSERT INTO `dbscripts_on_quest_end` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (9029, 41, 0, 0, 0, 0, 0, 0, 2000000208, 0, 0, 0, 0, 0, 0, 0, 'Staffron Dialogue 4');
+INSERT INTO `dbscripts_on_quest_end` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (9029, 45, 0, 0, 0, 0, 0, 0, 2000000209, 0, 0, 0, 0, 0, 0, 0, 'Staffron Dialogue 5');
+INSERT INTO `dbscripts_on_quest_end` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (9029, 49, 0, 0, 0, 0, 0, 0, 2000000210, 0, 0, 0, 0, 0, 0, 0, 'Staffron Dialogue 6');
+INSERT INTO `dbscripts_on_quest_end` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (9029, 53, 0, 0, 0, 0, 0, 0, 2000000211, 0, 0, 0, 0, 0, 0, 0, 'Staffron Dialogue 7');
+

--- a/Updates/Red Roses.sql
+++ b/Updates/Red Roses.sql
@@ -1,0 +1,5 @@
+-- Adding Bouquest of Red Roses to loot tables, assuming 100% drop rate and in addition to normal loot
+INSERT INTO `creature_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`, `comments`) VALUES (11488, 22206, 100, 3, 1, 1, 500, ''); -- Ravenoak
+INSERT INTO `creature_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`, `comments`) VALUES (8929, 22206, 100, 2, 1, 1, 500, ''); -- Moira
+INSERT INTO `creature_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`, `comments`) VALUES (10811, 22206, 100, 2, 1, 1, 500, ''); -- Galford
+INSERT INTO `creature_loot_template` (`entry`, `item`, `ChanceOrQuestChance`, `groupid`, `mincountOrRef`, `maxcount`, `condition_id`, `comments`) VALUES (10901, 22206, 100, 2, 1, 1, 500, ''); -- Polkelt

--- a/Updates/Spell.sql
+++ b/Updates/Spell.sql
@@ -1,0 +1,8 @@
+-- Adding support scripts for Love is in the Air sequence at start and end of event
+
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 14, 27654, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Test');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 14, 27741, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 15, 26879, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast Remove Amorous');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 1, 15, 27741, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast Love is in the Air'); -- Need to cast after Love is in the Air to apply tooltip
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 15, 26869, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast Amorous');
+

--- a/Updates/Stormwind City Guards.sql
+++ b/Updates/Stormwind City Guards.sql
@@ -80,26 +80,30 @@ INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalon
 INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 14438, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Pomeroy');
 UPDATE `creature_template` SET `GossipMenuId`= 12864 WHERE `Entry`= 14438;
 
-/* Below handled in SD2 
+
 
 -- Adding gossip and conditions
 
 -- Changing standard gossip to display only outside of event
 UPDATE `gossip_menu` SET `condition_id`= 501 WHERE `entry`= 435 and `text_id`= 933;
 
--- Love Tokens(Normal Valentime Gossip)
+-- Love Tokens(Normal Valentine Gossip)
 INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (435, 8245, 0, 507);
 
--- Adding token menu option
-INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (435, 16, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 0, 0, 0, NULL, 528);
+-- Adding token menu options
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (435, 16, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 43501, 0, 0, NULL, 537); -- Female Guard
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (435, 17, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 43501, 0, 0, NULL, 539); -- Male Guard
 
 -- Heartbroken gossip
 INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (435, 8282, 0, 508);
 
--- No Perfume or Cologne gossip (Need to change/remove this when gender check in place)
-INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (435, 8303, 0, 530);
+-- No Cologne gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (435, 8287, 0, 540);
 
--- Cast Valentine(26924) in response to receiving love token
+-- No Perfume gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (435, 8289, 0, 542);
+
+-- Cast Valentine(27548) in response to receiving love token
 INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (43501, 0, 15, 27548, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Stormwind Guard on player');
 INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (43501, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
 
@@ -109,10 +113,7 @@ INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALU
 -- No Token Gossip
 INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (435, 8291, 0, 524);
 
-UPDATE `gossip_menu_option` SET `action_script_id`= 43501 WHERE `menu_id`= 435 AND `id`= 16;
-
-
-
+/*
 -- SW Royal Guards (not implemented) INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79747, 0, 0, 0, 27654, 0, 8);
 INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10506, 0, 0, 0, 27654, 0, 8);
 INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10508, 0, 0, 0, 27654, 0, 8);

--- a/Updates/Stormwind City Guards.sql
+++ b/Updates/Stormwind City Guards.sql
@@ -1,0 +1,140 @@
+-- Stormwind Guards and Gossip
+
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (189, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (190, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (2473, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (19272, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (19273, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26833, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79664, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79666, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79669, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79671, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79674, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79679, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79687, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79689, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79704, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79730, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79731, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79732, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79733, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79819, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79840, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79857, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79859, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79861, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79863, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79864, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79865, 0, 0, 0, 27654, 0, 8);
+
+-- Stormwind City Patrollers
+
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (12088, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (12093, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79670, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79675, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79690, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79792, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79807, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79814, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (90438, 0, 0, 0, 27654, 0, 8);
+
+-- Officers
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79768, 0, 0, 0, 27654, 0, 8); -- Brady
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79818, 0, 0, 0, 27654, 0, 8); -- Jaxon
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (90484, 0, 0, 0, 27654, 0, 8); -- Pomeroy
+
+-- Adding Gossip options to turn on during event and off after
+
+-- SW Officer template - Gossip Menu + Options
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12864, 8245, 0, 507);
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12864, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 1286401, 0, 0, NULL, 523);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12864, 8283, 0, 508);
+-- No Perfume gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12864, 8289, 0, 520);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12864, 8296, 0, 518);
+-- Cast Valentine(27548) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1286401, 0, 15, 27548, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine SW Guard on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1286401, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12864, 8291, 0, 524);
+
+
+-- Officer Brady
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 14439, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Brady');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 14439, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Brady');
+UPDATE `creature_template` SET `GossipMenuId`= 12864 WHERE `Entry`= 14439;
+
+-- Officer Jaxon
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 14423, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Jaxon');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 14423, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Jaxon');
+UPDATE `creature_template` SET `GossipMenuId`= 12864 WHERE `Entry`= 14423;
+-- Officer Pomeroy
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 14438, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Pomeroy');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 14438, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Pomeroy');
+UPDATE `creature_template` SET `GossipMenuId`= 12864 WHERE `Entry`= 14438;
+
+/* Below handled in SD2 
+
+-- Adding gossip and conditions
+
+-- Changing standard gossip to display only outside of event
+UPDATE `gossip_menu` SET `condition_id`= 501 WHERE `entry`= 435 and `text_id`= 933;
+
+-- Love Tokens(Normal Valentime Gossip)
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (435, 8245, 0, 507);
+
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (435, 16, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 0, 0, 0, NULL, 528);
+
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (435, 8282, 0, 508);
+
+-- No Perfume or Cologne gossip (Need to change/remove this when gender check in place)
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (435, 8303, 0, 530);
+
+-- Cast Valentine(26924) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (43501, 0, 15, 27548, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Stormwind Guard on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (43501, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (435, 8296, 0, 518);
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (435, 8291, 0, 524);
+
+UPDATE `gossip_menu_option` SET `action_script_id`= 43501 WHERE `menu_id`= 435 AND `id`= 16;
+
+
+
+-- SW Royal Guards (not implemented) INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79747, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10506, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10508, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10510, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10527, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10528, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10523, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10524, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10525, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10526, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10512, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10511, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10516, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10518, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (51984, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10519, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10517, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10515, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10513, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10514, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10521, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (10522, 0, 0, 0, 27654, 0, 8);
+
+-- Major Samuelson(not implemented)
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (16182, 0, 0, 0, 27654, 0, 8); */

--- a/Updates/Stormwind Civilians.sql
+++ b/Updates/Stormwind Civilians.sql
@@ -1,0 +1,438 @@
+-- Adding Game event entries for each npc
+-- Vendors
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79663, 0, 0, 0, 27654, 0, 8); -- Ben Trias
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79665, 0, 0, 0, 27654, 0, 8); -- Elaine Trias
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79723, 0, 0, 0, 27654, 0, 8); -- Thomas Miller
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79686, 0, 0, 0, 27654, 0, 8); -- Kyra Boucher
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79682, 0, 0, 0, 27654, 0, 8); -- Keldric Boucher
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79672, 0, 0, 0, 27654, 0, 8); -- Edna Mullby
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79673, 0, 0, 0, 27654, 0, 8); -- Thurman Mullby
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79696, 0, 0, 0, 27654, 0, 8); -- Marda Weller
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79697, 0, 0, 0, 27654, 0, 8); -- Gunther Weller
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79715, 0, 0, 0, 27654, 0, 8); -- Carla Granger
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79717, 0, 0, 0, 27654, 0, 8); -- Lara Moore
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79714, 0, 0, 0, 27654, 0, 8); -- Aldric Moore
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (91691, 0, 0, 0, 27654, 0, 8); -- Colara Dean
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79799, 0, 0, 0, 27654, 0, 8); -- Lina Stover
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79797, 0, 0, 0, 27654, 0, 8); -- Frederick Stover
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79798, 0, 0, 0, 27654, 0, 8); -- Lisbeth Schneider
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79835, 0, 0, 0, 27654, 0, 8); -- Catherine Leland
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79837, 0, 0, 0, 27654, 0, 8); -- Roberto Pupellyverbos
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79838, 0, 0, 0, 27654, 0, 8); -- Julia Gallina
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (53686, 0, 0, 0, 27654, 0, 8); -- Adair Gilroy
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (61960, 0, 0, 0, 27654, 0, 8); -- Jessara Cordell
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79822, 0, 0, 0, 27654, 0, 8); -- Duncan Cullen
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79823, 0, 0, 0, 27654, 0, 8); -- Alexandra Bolero
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79831, 0, 0, 0, 27654, 0, 8); -- Maria Lumere
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (52921, 0, 0, 0, 27654, 0, 8); -- Owen Vaughn
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (52922, 0, 0, 0, 27654, 0, 8); -- Wynne Larson
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (52923, 0, 0, 0, 27654, 0, 8); -- Evan Larson
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (52920, 0, 0, 0, 27654, 0, 8); -- Charys Yserian
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (43441, 0, 0, 0, 27654, 0, 8); -- Darian Singh
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (52925, 0, 0, 0, 27654, 0, 8); -- Ardwyn Cailen
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79827, 0, 0, 0, 27654, 0, 8); -- Allan Hafgan
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79809, 0, 0, 0, 27654, 0, 8); -- Theresa Moulaine
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79802, 0, 0, 0, 27654, 0, 8); -- Agustus Moulaine
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (7626, 0, 0, 0, 27654, 0, 8); -- Gregory Ardus
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (37605, 0, 0, 0, 27654, 0, 8); -- Kaita Deepforge
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (37607, 0, 0, 0, 27654, 0, 8); -- Brooke Stonebraid
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (37602, 0, 0, 0, 27654, 0, 8); -- Kathrum Axehand
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (37612, 0, 0, 0, 27654, 0, 8); -- Billibub Cogspinner
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79728, 0, 0, 0, 27654, 0, 8); -- Jillian Tanner
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79726, 0, 0, 0, 27654, 0, 8); -- Alyssa Griffith
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79737, 0, 0, 0, 27654, 0, 8); -- Seoman Griffith
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (590006, 0, 0, 0, 27654, 0, 8); -- Officer Areyn
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79771, 0, 0, 0, 27654, 0, 8); -- Osric Strang
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79772, 0, 0, 0, 27654, 0, 8); -- Wilhelm Strang
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79774, 0, 0, 0, 27654, 0, 8); -- Heinrich Stone
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79756, 0, 0, 0, 27654, 0, 8); -- Erika Tate
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79776, 0, 0, 0, 27654, 0, 8); -- Elly Langston
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79754, 0, 0, 0, 27654, 0, 8); -- Kendor Kabonka
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79729, 0, 0, 0, 27654, 0, 8); -- Bryan Cross
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79744, 0, 0, 0, 27654, 0, 8); -- Gerik Koen
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79738, 0, 0, 0, 27654, 0, 8); -- Mayda Thane
+
+
+-- Questgivers
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79654, 0, 0, 0, 27654, 0, 8); -- Jorgen
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79668, 0, 0, 0, 27654, 0, 8); -- Elling Trias
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79683, 0, 0, 0, 27654, 0, 8); -- Morgan Pestle
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79680, 0, 0, 0, 27654, 0, 8); -- Stephanie Turner
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79716, 0, 0, 0, 27654, 0, 8); -- Harlan Bagley
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (91692, 0, 0, 0, 27654, 0, 8); -- Aristan Mottar
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79800, 0, 0, 0, 27654, 0, 8); -- Rema Schneider
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79839, 0, 0, 0, 27654, 0, 8); -- Suzetta Gallina
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26836, 0, 0, 0, 27654, 0, 8); -- Mazen Mac'Nadir
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (90459, 0, 0, 0, 27654, 0, 8); -- Acolyte Dellis
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79820, 0, 0, 0, 27654, 0, 8); -- Collin Mauren
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (54399, 0, 0, 0, 27654, 0, 8); -- Connor Rivers
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38225, 0, 0, 0, 27654, 0, 8); -- Angus Stern
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (90452, 0, 0, 0, 27654, 0, 8); -- Argos Nightwhisper
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26834, 0, 0, 0, 27654, 0, 8); -- Caretaker Folsom
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79559, 0, 0, 0, 27654, 0, 8); -- Evert Sorisam
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79766, 0, 0, 0, 27654, 0, 8); -- Baros Alexston
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79810, 0, 0, 0, 27654, 0, 8); -- Brother Kristoff
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (44022, 0, 0, 0, 27654, 0, 8); -- Brother Sarno
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (39536, 0, 0, 0, 27654, 0, 8); -- Duthorian Rall
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (7450, 0, 0, 0, 27654, 0, 8); -- Bishop Farthing
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (39538, 0, 0, 0, 27654, 0, 8); -- Gazin Tenorm
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (52472, 0, 0, 0, 27654, 0, 8); -- Brother Crowley
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (35221, 0, 0, 0, 27654, 0, 8); -- Brohann Caskbelly
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (2435, 0, 0, 0, 27654, 0, 8); -- Wilder Thistelnettle
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (41677, 0, 0, 0, 27654, 0, 8); -- Shoni the Silent
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (43705, 0, 0, 0, 27654, 0, 8); -- Hank the Hammer
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (35250, 0, 0, 0, 27654, 0, 8); -- Furen Longbeard
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79770, 0, 0, 0, 27654, 0, 8); -- Nikova Raskol
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (16365, 0, 0, 0, 27654, 0, 8); -- Donyal Tovald
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (8704, 0, 0, 0, 27654, 0, 8); -- Milton Sheaf
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (33821, 0, 0, 0, 27654, 0, 8); -- Bishop DeLavey
+
+-- Non Vendor/Questgiver
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79724, 0, 0, 0, 27654, 0, 8); -- Topper McNabb
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (90445, 0, 0, 0, 27654, 0, 8); -- Eric Lohan
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (90483, 0, 0, 0, 27654, 0, 8); -- Imelda
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (90481, 0, 0, 0, 27654, 0, 8); -- Kimberly Grant
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (90482, 0, 0, 0, 27654, 0, 8); -- Kelly Grant
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (90477, 0, 0, 0, 27654, 0, 8); -- Shailiea
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (86597, 0, 0, 0, 27654, 0, 8); -- Lisan Pierce
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (86596, 0, 0, 0, 27654, 0, 8); -- Janey Anship
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (89294, 0, 0, 0, 27654, 0, 8); -- Suzanne
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79808, 0, 0, 0, 27654, 0, 8); -- Morris Lawry
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79811, 0, 0, 0, 27654, 0, 8); -- Shellene
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (8733, 0, 0, 0, 27654, 0, 8); -- Morgg Stormshot
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79752, 0, 0, 0, 27654, 0, 8); -- Aedis Brom
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79753, 0, 0, 0, 27654, 0, 8); -- Christoph Faral
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79775, 0, 0, 0, 27654, 0, 8); -- David Langston
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79746, 0, 0, 0, 27654, 0, 8); -- Jenn Langston
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79739, 0, 0, 0, 27654, 0, 8); -- Ol' Beasley
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (79740, 0, 0, 0, 27654, 0, 8); -- Lenny McCoy
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (90439, 0, 0, 0, 27654, 0, 8); -- Karlee Chaddis
+
+
+-- Adding/Removing Gossip option
+-- Human Vendor
+-- Adjusting Gossip menus to align female to 685 gossips and male to 686 gossips as required
+
+UPDATE `creature_template` SET `GossipMenuId`= 686 WHERE `Entry`= 4981; -- Ben Trias
+UPDATE `creature_template` SET `GossipMenuId`= 686 WHERE `Entry`= 482; -- Elling Trias
+UPDATE `creature_template` SET `GossipMenuId`= 686 WHERE `Entry`= 3518; -- Thomas Miller
+UPDATE `creature_template` SET `GossipMenuId`= 685 WHERE `Entry`= 1275; -- Kyra Boucher
+UPDATE `creature_template` SET `GossipMenuId`= 686 WHERE `Entry`= 1257; -- Keldric Boucher
+UPDATE `creature_template` SET `GossipMenuId`= 685 WHERE `Entry`= 1286; -- Edna Mullby
+UPDATE `creature_template` SET `GossipMenuId`= 686 WHERE `Entry`= 1285; -- Thurman Mullby
+UPDATE `creature_template` SET `GossipMenuId`= 686 WHERE `Entry`= 1289; -- Gunther Weller
+UPDATE `creature_template` SET `GossipMenuId`= 685 WHERE `Entry`= 1295; -- Lara Moore
+UPDATE `creature_template` SET `GossipMenuId`= 686 WHERE `Entry`= 1294; -- Aldric Moore
+UPDATE `creature_template` SET `GossipMenuId`= 685 WHERE `Entry`= 16002; -- Colara Dean
+UPDATE `creature_template` SET `GossipMenuId`= 685 WHERE `Entry`= 1297; -- Lina Stover
+UPDATE `creature_template` SET `GossipMenuId`= 686 WHERE `Entry`= 1298; -- Frederick Stover
+UPDATE `creature_template` SET `GossipMenuId`= 686 WHERE `Entry`= 277; -- Roberto Pupellyverbos
+UPDATE `creature_template` SET `GossipMenuId`= 682 WHERE `Entry`= 1314; -- Duncan Cullen
+UPDATE `creature_template` SET `GossipMenuId`= 681 WHERE `Entry`= 1347; -- Alexandra Bolero
+UPDATE `creature_template` SET `GossipMenuId`= 682 WHERE `Entry`= 1308; -- Owen Vaughn
+UPDATE `creature_template` SET `GossipMenuId`= 682 WHERE `Entry`= 1310; -- Evan Larson
+UPDATE `creature_template` SET `GossipMenuId`= 682 WHERE `Entry`= 1315; -- Allan Hafgan
+UPDATE `creature_template` SET `GossipMenuId`= 692 WHERE `Entry`= 1349; -- Agustus Moulaine
+UPDATE `creature_template` SET `GossipMenuId`= 692 WHERE `Entry`= 1348; -- Gregory Ardus
+UPDATE `creature_template` SET `GossipMenuId`= 694 WHERE `Entry`= 5509; -- Kathrum Axehand
+UPDATE `creature_template` SET `GossipMenuId`= 689 WHERE `Entry`= 1320; -- Seoman Griffith
+UPDATE `creature_template` SET `GossipMenuId`= 689 WHERE `Entry`= 1323; -- Osric Strang
+UPDATE `creature_template` SET `GossipMenuId`= 689 WHERE `Entry`= 1324; -- Heinrich Stone
+UPDATE `creature_template` SET `GossipMenuId`= 689 WHERE `Entry`= 1319; -- Bryan Cross
+UPDATE `creature_template` SET `GossipMenuId`= 689 WHERE `Entry`= 1333; -- Gerik Koen
+UPDATE `creature_template` SET `GossipMenuId`= 689 WHERE `Entry`= 1339; -- Mayda Thane
+
+-- These vendors have no gossip, so they need to have gossips added for event and removed after event.
+-- Carla Granger
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 1291, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Carla');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 1291, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Carla');
+UPDATE `creature_template` SET `GossipMenuId`= 685 WHERE `Entry`= 1291;
+
+-- Adair Gilroy
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 1316, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Adair');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 1316, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Adair');
+UPDATE `creature_template` SET `GossipMenuId`= 686 WHERE `Entry`= 1316;
+
+-- Officer Areyn
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 12805, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Areyn');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 12805, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Areyn');
+UPDATE `creature_template` SET `GossipMenuId`= 688 WHERE `Entry`= 12805;
+
+-- Elly Langston
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 1328, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Elly');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 1328, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Elly');
+UPDATE `creature_template` SET `GossipMenuId`= 688 WHERE `Entry`= 1328;
+
+-- Kendor Kabonka
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 340, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Kendor');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 340, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Kendor');
+UPDATE `creature_template` SET `GossipMenuId`= 689 WHERE `Entry`= 340;
+
+
+-- SW Questgiver
+-- Adding/Removing Gossip option
+-- Jorgen
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4959, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Jorgen');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4959, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Jorgen');
+UPDATE `creature_template` SET `GossipMenuId`= 686 WHERE `Entry`= 4959;
+
+-- Elling Trias
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 482, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Elling');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 482, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Elling');
+UPDATE `creature_template` SET `GossipMenuId`= 686 WHERE `Entry`= 482;
+
+-- Morgan Pestle
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 279, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Morgan');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 279, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Morgan');
+UPDATE `creature_template` SET `GossipMenuId`= 686 WHERE `Entry`= 279;
+
+-- Stephanie Turner
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 6174, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Stephanie');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 6174, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Stephanie');
+UPDATE `creature_template` SET `GossipMenuId`= 685 WHERE `Entry`= 6174;
+
+-- Harlan Bagley
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 1427, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Harlan');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 1427, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Harlan');
+UPDATE `creature_template` SET `GossipMenuId`= 686 WHERE `Entry`= 1427;
+
+-- Aristan Mottar
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 16105, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Aristan');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 16105, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Aristan');
+UPDATE `creature_template` SET `GossipMenuId`= 686 WHERE `Entry`= 16105;
+
+-- Rema Schneider
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 1428, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Rema');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 1428, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Rema');
+UPDATE `creature_template` SET `GossipMenuId`= 685 WHERE `Entry`= 1428;
+
+-- Suzetta Gallina
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 1431, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Suzetta');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 1431, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Suzetta');
+UPDATE `creature_template` SET `GossipMenuId`= 685 WHERE `Entry`= 1431;
+
+-- Mazen Mac'Nadir
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 338, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Mazen');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 338, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Mazen');
+UPDATE `creature_template` SET `GossipMenuId`= 686 WHERE `Entry`= 338;
+
+-- Acolyte Dellis
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5386, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Suzetta');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5386, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Suzetta');
+UPDATE `creature_template` SET `GossipMenuId`= 686 WHERE `Entry`= 5386;
+
+-- Collin Mauren
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4078, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Collin');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4078, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Collin');
+UPDATE `creature_template` SET `GossipMenuId`= 682 WHERE `Entry`= 4078;
+
+-- Angus Stern
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 1141, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Angus');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 1141, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Angus');
+UPDATE `creature_template` SET `GossipMenuId`= 682 WHERE `Entry`= 1141;
+
+-- Connor Rivers
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5081, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Connor');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5081, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Connor');
+UPDATE `creature_template` SET `GossipMenuId`= 682 WHERE `Entry`= 5081;
+
+-- Argos Nightwhisper
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4984, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Argos');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4984, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Argos');
+UPDATE `creature_template` SET `GossipMenuId`= 682 WHERE `Entry`= 4984;
+
+-- Caretaker Folsom
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 297, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Folsom');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 297, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Folsom');
+UPDATE `creature_template` SET `GossipMenuId`= 682 WHERE `Entry`= 297;
+
+-- Evert Sorisam
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 16106, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Evert');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 16106, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Evert');
+UPDATE `creature_template` SET `GossipMenuId`= 692 WHERE `Entry`= 16106;
+
+-- Baros Alexston
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 1646, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Baros');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 1646, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Baros');
+UPDATE `creature_template` SET `GossipMenuId`= 692 WHERE `Entry`= 1646;
+
+-- Brother Kristoff
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 1444, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Kristoff');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 1444, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Kristoff');
+UPDATE `creature_template` SET `GossipMenuId`= 692 WHERE `Entry`= 1444;
+
+-- Brother Sarno
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 7917, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Sarno');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 7917, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Sarno');
+UPDATE `creature_template` SET `GossipMenuId`= 692 WHERE `Entry`= 7917;
+
+-- Duthorian Rall
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 6171, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Duthorian');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 6171, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Duthorian');
+UPDATE `creature_template` SET `GossipMenuId`= 692 WHERE `Entry`= 6171;
+
+-- Bishop Farthing
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 1212, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Farthing');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 1212, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Farthing');
+UPDATE `creature_template` SET `GossipMenuId`= 692 WHERE `Entry`= 1212;
+
+-- Gazin Tenorm
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 6173, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Gazin');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 6173, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Gazin');
+UPDATE `creature_template` SET `GossipMenuId`= 692 WHERE `Entry`= 6173;
+
+-- Brother Crowley
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 12336, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Crowley');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 12336, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Crowley');
+UPDATE `creature_template` SET `GossipMenuId`= 692 WHERE `Entry`= 12336;
+
+-- Brohann Caskbelly
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5384, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Brohann');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5384, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Brohann');
+UPDATE `creature_template` SET `GossipMenuId`= 694 WHERE `Entry`= 5384;
+
+-- Wilder Thistlenettle
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 656, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Wilder');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 656, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Wilder');
+UPDATE `creature_template` SET `GossipMenuId`= 694 WHERE `Entry`= 656;
+
+-- Shoni the Silent
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 6579, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Shoni');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 6579, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Shoni');
+UPDATE `creature_template` SET `GossipMenuId`= 697 WHERE `Entry`= 6579;
+
+-- Hank the Hammer
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 7798, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Hank');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 7798, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Hank');
+UPDATE `creature_template` SET `GossipMenuId`= 692 WHERE `Entry`= 7798;
+
+-- Furen Longbeard
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5413, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Furen');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5413, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Furen');
+UPDATE `creature_template` SET `GossipMenuId`= 694 WHERE `Entry`= 5413;
+
+-- Nikova Raskol
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 1721, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Nikova');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 1721, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Nikova');
+UPDATE `creature_template` SET `GossipMenuId`= 688 WHERE `Entry`= 1721;
+
+-- Donyal Tovald
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 2504, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Donyal');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 2504, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Donyal');
+UPDATE `creature_template` SET `GossipMenuId`= 689 WHERE `Entry`= 2504;
+
+-- Milton Sheaf
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 1440, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Milton');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 1440, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Milton');
+UPDATE `creature_template` SET `GossipMenuId`= 689 WHERE `Entry`= 1440;
+
+-- Bishop DeLavey
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4960, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to DeLavey');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4960, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from DeLavey');
+UPDATE `creature_template` SET `GossipMenuId`= 692 WHERE `Entry`= 4960;
+
+
+
+-- Non-Vendor/Questgiver
+-- Topper McNabb
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 1402, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Topper');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 1402, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Topper');
+UPDATE `creature_template` SET `GossipMenuId`= 686 WHERE `Entry`= 1402;
+
+-- Eric Lohan
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3627, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Eric');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3627, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Eric');
+UPDATE `creature_template` SET `GossipMenuId`= 682 WHERE `Entry`= 3627;
+
+-- Imelda
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 11916, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Imelda');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 11916, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Imelda');
+UPDATE `creature_template` SET `GossipMenuId`= 681 WHERE `Entry`= 11916;
+
+-- Kimberly Grant
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 11827, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Kimberly');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 11827, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Kimberly');
+UPDATE `creature_template` SET `GossipMenuId`= 681 WHERE `Entry`= 11827;
+
+-- Kelly Grant
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 11828, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Kelly');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 11828, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Kelly');
+UPDATE `creature_template` SET `GossipMenuId`= 681 WHERE `Entry`= 11828;
+
+-- Shailiea
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 7295, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Shailiea');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 7295, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Shailiea');
+UPDATE `creature_template` SET `GossipMenuId`= 681 WHERE `Entry`= 7295;
+
+-- Lisan Pierce
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 1414, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Lisan');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 1414, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Lisan');
+UPDATE `creature_template` SET `GossipMenuId`= 681 WHERE `Entry`= 1414;
+
+-- Janey Anship
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 1413, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Janey');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 1413, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Janey');
+UPDATE `creature_template` SET `GossipMenuId`= 681 WHERE `Entry`= 1413;
+
+-- Suzanne
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 1415, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Suzanne');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 1415, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Suzanne');
+UPDATE `creature_template` SET `GossipMenuId`= 681 WHERE `Entry`= 1415;
+
+-- Morris Lawry
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 1405, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Morris');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 1405, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Morris');
+UPDATE `creature_template` SET `GossipMenuId`= 682 WHERE `Entry`= 1405;
+
+-- Shellene
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 14497, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Shellene');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 14497, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Shellene');
+UPDATE `creature_template` SET `GossipMenuId`= 681 WHERE `Entry`= 14497;
+
+-- Morgg Stormshot
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 1472, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Morgg');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 1472, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Morgg');
+UPDATE `creature_template` SET `GossipMenuId`= 694 WHERE `Entry`= 1472;
+
+-- Aedis Brom
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 1478, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Aedis');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 1478, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Aedis');
+UPDATE `creature_template` SET `GossipMenuId`= 689 WHERE `Entry`= 1478;
+
+-- Christoph Faral
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 1477, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Christoph');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 1477, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Christoph');
+UPDATE `creature_template` SET `GossipMenuId`= 689 WHERE `Entry`= 1477;
+
+-- David Langston
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3629, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to David Langston');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3629, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from David Langston');
+UPDATE `creature_template` SET `GossipMenuId`= 689 WHERE `Entry`= 3629;
+
+-- Jenn Langston
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3626, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Jenn Langston');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3626, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Jenn Langston');
+UPDATE `creature_template` SET `GossipMenuId`= 688 WHERE `Entry`= 3626;
+
+-- Ol' Beasley
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 1395, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Ol Beasley');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 1395, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Ol Beasley');
+UPDATE `creature_template` SET `GossipMenuId`= 689 WHERE `Entry`= 1395;
+
+-- Lenny Mccoy
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 2795, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Lenny');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 2795, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Lenny');
+UPDATE `creature_template` SET `GossipMenuId`= 689 WHERE `Entry`= 2795;
+
+-- Karleee Chaddis
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 2330, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Karlee');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 2330, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Karlee');
+UPDATE `creature_template` SET `GossipMenuId`= 681 WHERE `Entry`= 2330;
+
+
+
+-- Problem NPCs Harry Burlguard(faction 123)
+-- Dashel Stonefist, Bartleby - faction 84 (no city affiliation) and involved in scripts - unsuitable
+-- Caledra Dawnbreeze faction 1576 unsuitable
+-- Wishock, Tyrion, Lescovar in scripts. unsuitable
+-- Npcs with original/non-generic gossip already Rebecca + Aldwin Laughlin, Renato Gallina, Bernard + Felicia Gump, Clavicus Knavingham, Eldraeith, High Sorcerer Andromath, Archmage Malin, Steven Lohan, Joachim Brenlow, Jarel Moor, Zardeth, Gakin, Bathrilor, Nightingale, Benedictus, Borgus Steelhand, Grimand Elmore, Reese Langston, Crier Goodman

--- a/Updates/Thunderbluff Civilians.sql
+++ b/Updates/Thunderbluff Civilians.sql
@@ -1,0 +1,268 @@
+-- Adding Game event entries
+
+-- Vendors
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26576, 0, 0, 0, 27654, 0, 8); -- Pakwa
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26573, 0, 0, 0, 27654, 0, 8); -- Kuruk
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26575, 0, 0, 0, 27654, 0, 8); -- Shadi Mistrunner
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26617, 0, 0, 0, 27654, 0, 8); -- Jyn Stonehoof
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26569, 0, 0, 0, 27654, 0, 8); -- Elki
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26565, 0, 0, 0, 27654, 0, 8); -- Hewa
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26572, 0, 0, 0, 27654, 0, 8); -- Chepi
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26622, 0, 0, 0, 27654, 0, 8); -- Fyr Mistrunner
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26621, 0, 0, 0, 27654, 0, 8); -- Kurm Stonehoof
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26619, 0, 0, 0, 27654, 0, 8); -- Taur Stonehoof
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26635, 0, 0, 0, 27654, 0, 8); -- Tand
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26629, 0, 0, 0, 27654, 0, 8); -- Mani Winterhoof
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26631, 0, 0, 0, 27654, 0, 8); -- Nata Dawnstrider
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26624, 0, 0, 0, 27654, 0, 8); -- Mahu
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24710, 0, 0, 0, 27654, 0, 8); -- Tagain
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24712, 0, 0, 0, 27654, 0, 8); -- Fela
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24711, 0, 0, 0, 27654, 0, 8); -- Grod
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26634, 0, 0, 0, 27654, 0, 8); -- Kuna Thunderhorn
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26636, 0, 0, 0, 27654, 0, 8); -- Nan Mistrunner
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26633, 0, 0, 0, 27654, 0, 8); -- Nida Winterhoof
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26641, 0, 0, 0, 27654, 0, 8); -- Sunn Ragetotem
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26648, 0, 0, 0, 27654, 0, 8); -- Kaga Mistrunner
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26653, 0, 0, 0, 27654, 0, 8); -- Sewa Mistrunner
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26637, 0, 0, 0, 27654, 0, 8); -- Hogor Thunderhoof
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26638, 0, 0, 0, 27654, 0, 8); -- Delgo Ragetotem
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26639, 0, 0, 0, 27654, 0, 8); -- Etu Ragetotem
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26642, 0, 0, 0, 27654, 0, 8); -- Ohanko
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26640, 0, 0, 0, 27654, 0, 8); -- Kard Ragetotem
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26645, 0, 0, 0, 27654, 0, 8); -- Sura Wildmane
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26650, 0, 0, 0, 27654, 0, 8); -- Naal Mistrunner
+
+
+-- Questgivers
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24933, 0, 0, 0, 27654, 0, 8); -- Sage Truthseeker
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24778, 0, 0, 0, 27654, 0, 8); -- Auld Stonespire
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26574, 0, 0, 0, 27654, 0, 8); -- Eyahn Eagletalon
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24678, 0, 0, 0, 27654, 0, 8); -- Orm Stonehoof
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26777, 0, 0, 0, 27654, 0, 8); -- Veren Tallstrider
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24790, 0, 0, 0, 27654, 0, 8); -- Zangen Stonehoof
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26567, 0, 0, 0, 27654, 0, 8); -- Clarice Foster
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24707, 0, 0, 0, 27654, 0, 8); -- Xanis Flameweaver
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (24934, 0, 0, 0, 27654, 0, 8); -- Nara Wildmane
+
+-- Non Questgiver/Vendors
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26646, 0, 0, 0, 27654, 0, 8); -- Tah Winterhoof
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26792, 0, 0, 0, 27654, 0, 8); -- Pawe Mistrunner
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (26754, 0, 0, 0, 27654, 0, 8); -- Sheza Wildmane
+-- Adding/Removing Gossip Options
+-- Vendors
+-- Pakwa
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 8364, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Pakwa');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 8364, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Pakwa');
+UPDATE `creature_template` SET `GossipMenuId`= 12856 WHERE `Entry`= 8364;  
+
+-- Kuruk
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 8362, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Kuruk');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 8362, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Kuruk');
+UPDATE `creature_template` SET `GossipMenuId`= 12857 WHERE `Entry`= 8362; 
+
+-- Shadi Mistrunner
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 8363, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Shadi');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 8363, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Shadi');
+UPDATE `creature_template` SET `GossipMenuId`= 12856 WHERE `Entry`= 8363;
+
+-- Jyn Stonehoof
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 2997, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Jyn');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 2997, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Jyn');
+UPDATE `creature_template` SET `GossipMenuId`= 12856 WHERE `Entry`= 2997;
+
+-- Elki
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 8360, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Elki');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 8360, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Elki');
+UPDATE `creature_template` SET `GossipMenuId`= 12857 WHERE `Entry`= 8360; 
+
+-- Hewa
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 8358, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Hewa');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 8358, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Hewa');
+UPDATE `creature_template` SET `GossipMenuId`= 12857 WHERE `Entry`= 8358;
+
+-- Chepi
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 8361, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Chepi');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 8361, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Chepi');
+UPDATE `creature_template` SET `GossipMenuId`= 12856 WHERE `Entry`= 8361;
+
+-- Fyr Mistrunner
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3003, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Fyr');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3003, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Fyr');
+UPDATE `creature_template` SET `GossipMenuId`= 12856 WHERE `Entry`= 3003;
+
+-- Kurm Stonehoof
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3002, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Kurm');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3002, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Kurm');
+UPDATE `creature_template` SET `GossipMenuId`= 12857 WHERE `Entry`= 3002;
+
+-- Taur Stonehoof
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 2999, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Taur');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 2999, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Taur');
+UPDATE `creature_template` SET `GossipMenuId`= 12857 WHERE `Entry`= 2999;
+
+-- Tand
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3016, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Tand');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3016, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Tand');
+UPDATE `creature_template` SET `GossipMenuId`= 12857 WHERE `Entry`= 3016;
+
+-- Mani Winterhoof
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3010, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Mani');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3010, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Mani');
+UPDATE `creature_template` SET `GossipMenuId`= 12856 WHERE `Entry`= 3010;
+
+-- Nata Dawnstrider
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3012, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Nata');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3012, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Nata');
+UPDATE `creature_template` SET `GossipMenuId`= 12856 WHERE `Entry`= 3012;
+
+-- Mahu
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3005, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Mahu');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3005, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Mahu');
+UPDATE `creature_template` SET `GossipMenuId`= 12857 WHERE `Entry`= 3005;
+
+-- Tagain
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3092, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Tagain');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3092, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Tagain');
+UPDATE `creature_template` SET `GossipMenuId`= 12856 WHERE `Entry`= 3092;
+
+-- Fela
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3095, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Fela');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3095, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Fela');
+UPDATE `creature_template` SET `GossipMenuId`= 12856 WHERE `Entry`= 3095;
+
+-- Grod
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3093, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Grod');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3093, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Grod');
+UPDATE `creature_template` SET `GossipMenuId`= 12857 WHERE `Entry`= 3093;
+
+-- Kuna Thinderhorn
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3015, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Kuna');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3015, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Kuna');
+UPDATE `creature_template` SET `GossipMenuId`= 12856 WHERE `Entry`= 3015;
+
+-- Nan Mistrunner
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3017, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Nan');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3017, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Nan');
+UPDATE `creature_template` SET `GossipMenuId`= 12856 WHERE `Entry`= 3017;
+
+-- Nida Winterhoof
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3014, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Nida');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3014, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Nida');
+UPDATE `creature_template` SET `GossipMenuId`= 12856 WHERE `Entry`= 3014;
+
+-- Sunn Ragetotem
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3022, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Sunn');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3022, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Sunn');
+UPDATE `creature_template` SET `GossipMenuId`= 12856 WHERE `Entry`= 3022;
+
+-- Kaga Mistrunner
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3025, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Kaga');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3025, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Kaga');
+UPDATE `creature_template` SET `GossipMenuId`= 12856 WHERE `Entry`= 3025;
+
+-- Sewa Mistrunner
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3029, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Sewa');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3029, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Sewa');
+UPDATE `creature_template` SET `GossipMenuId`= 12856 WHERE `Entry`= 3029;
+
+-- Hogor Thunderhoof
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3018, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Hogor');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3018, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Hogor');
+UPDATE `creature_template` SET `GossipMenuId`= 12857 WHERE `Entry`= 3018;
+
+-- Delgo Ragetotem
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3019, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Delgo');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3019, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Delgo');
+UPDATE `creature_template` SET `GossipMenuId`= 12857 WHERE `Entry`= 3019;
+
+-- Etu Ragetotem
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3020, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Etu');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3020, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Etu');
+UPDATE `creature_template` SET `GossipMenuId`= 12857 WHERE `Entry`= 3020;
+
+-- Ohanko
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 8398, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Ohanko');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 8398, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Ohanko');
+UPDATE `creature_template` SET `GossipMenuId`= 12857 WHERE `Entry`= 8398;
+
+-- Kard Ragetotem
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3021, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Kard');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3021, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Kard');
+UPDATE `creature_template` SET `GossipMenuId`= 12857 WHERE `Entry`= 3021;
+
+-- Sura Wildmane
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3023, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Sura');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3023, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Sura');
+UPDATE `creature_template` SET `GossipMenuId`= 12856 WHERE `Entry`= 3023;
+
+-- Naal Mistrunner
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3027, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Naal');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3027, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Naal');
+UPDATE `creature_template` SET `GossipMenuId`= 12857 WHERE `Entry`= 3027;
+
+-- Questgivers
+-- Sage Truthseeker
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3978, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Sage');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3978, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Sage');
+UPDATE `creature_template` SET `GossipMenuId`= 12857 WHERE `Entry`= 3978;
+
+-- Auld Stonespire
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4451, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Auld');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4451, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Auld');
+UPDATE `creature_template` SET `GossipMenuId`= 12857 WHERE `Entry`= 4451;
+
+-- Eyahn Eagletalon
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 2987, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Eyahn');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 2987, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Eyahn');
+UPDATE `creature_template` SET `GossipMenuId`= 12857 WHERE `Entry`= 2987;
+
+-- Orm Stonehoof
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 6410, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Orm');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 6410, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Orm');
+UPDATE `creature_template` SET `GossipMenuId`= 12857 WHERE `Entry`= 6410;
+
+-- Veren Tallstrider
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3050, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Veren');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3050, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Veren');
+UPDATE `creature_template` SET `GossipMenuId`= 12857 WHERE `Entry`= 3050;
+
+-- Zangen Stonehoof
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4721, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Zangen');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4721, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Zangen');
+UPDATE `creature_template` SET `GossipMenuId`= 12857 WHERE `Entry`= 4721;
+
+-- Clarice Foster
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5543, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Clarice');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5543, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Clarice');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 5543;
+
+-- Xanis Flameweaver
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5906, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Xanis');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5906, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Xanis');
+UPDATE `creature_template` SET `GossipMenuId`= 12857 WHERE `Entry`= 5906;
+
+-- Nara Wildmane
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5906, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Nara');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5906, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Nara');
+UPDATE `creature_template` SET `GossipMenuId`= 12856 WHERE `Entry`= 5770;
+
+-- Non Questgiver/Vendors
+-- Tah Winterhoof
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3024, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Tah');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3024, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Tah');
+UPDATE `creature_template` SET `GossipMenuId`= 12857 WHERE `Entry`= 3024;
+
+-- Pawe Mistrunner
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3447, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Pawe');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3447, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Pawe');
+UPDATE `creature_template` SET `GossipMenuId`= 12856 WHERE `Entry`= 3447;
+
+-- Sheza Wildmane
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 3037, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Sheza');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 3037, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Sheza');
+UPDATE `creature_template` SET `GossipMenuId`= 12856 WHERE `Entry`= 3037;
+
+
+
+
+-- Ahanu, Thrumn, Krumn, Apothecary Zamrah, Saern Priderunner, Bluff Runner Windstrider(specific gossip), Magatha, Cor and Gorm Grimtotem, Hamuul Runetotem, Rahauro, Kon Yelloweyes + Melor Stonehoof + Henen Ragetotem + Mosarn(faction 83)

--- a/Updates/Undercity Civilians.sql
+++ b/Updates/Undercity Civilians.sql
@@ -1,0 +1,513 @@
+-- Adding Game event entries
+
+-- Vendors
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38061, 0, 0, 0, 27654, 0, 8); -- Louis Warren
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (30405, 0, 0, 0, 27654, 0, 8); -- Timothy Weldon
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38062, 0, 0, 0, 27654, 0, 8); -- Walter Ellingson
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38056, 0, 0, 0, 27654, 0, 8); -- Lauren Newcomb
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38400, 0, 0, 0, 27654, 0, 8); -- Daniel Bartlett
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38408, 0, 0, 0, 27654, 0, 8); -- Tawny Grisette
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38411, 0, 0, 0, 27654, 0, 8); -- Thomas Mordan
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (31859, 0, 0, 0, 27654, 0, 8); -- Eleanor Rusk
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38053, 0, 0, 0, 27654, 0, 8); -- Felicia Doan
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38409, 0, 0, 0, 27654, 0, 8); -- Ronald Burch
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (31804, 0, 0, 0, 27654, 0, 8); -- Jeremiah Payson
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (41839, 0, 0, 0, 27654, 0, 8); -- Nicholas Atwood
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (41838, 0, 0, 0, 27654, 0, 8); -- Mirelle Tremayne
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (31898, 0, 0, 0, 27654, 0, 8); -- Samuel Van Brunt
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38109, 0, 0, 0, 27654, 0, 8); -- Francis Eliot
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38426, 0, 0, 0, 27654, 0, 8); -- Benijah Fenner
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (41837, 0, 0, 0, 27654, 0, 8); -- Geoffrey Hartwell
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38433, 0, 0, 0, 27654, 0, 8); -- Sarah Killian
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (31896, 0, 0, 0, 27654, 0, 8); -- Abigail Sawyer
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38092, 0, 0, 0, 27654, 0, 8); -- Katrina Alliestar
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (31874, 0, 0, 0, 27654, 0, 8); -- Thaddeus Webb
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (31886, 0, 0, 0, 27654, 0, 8); -- Jonathan Chambers
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (31888, 0, 0, 0, 27654, 0, 8); -- Gillian Moore
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (31881, 0, 0, 0, 27654, 0, 8); -- Joseph Moore
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (31883, 0, 0, 0, 27654, 0, 8); -- Ezekiel Graves
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38099, 0, 0, 0, 27654, 0, 8); -- Charles Seaton
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (31880, 0, 0, 0, 27654, 0, 8); -- Nathaniel Steenwick
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38070, 0, 0, 0, 27654, 0, 8); -- Salazar Bloch
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (31860, 0, 0, 0, 27654, 0, 8); -- Lucille Castleton
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38068, 0, 0, 0, 27654, 0, 8); -- Millie Gregorian
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38065, 0, 0, 0, 27654, 0, 8); -- Sheldon Von Croy
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38064, 0, 0, 0, 27654, 0, 8); -- Sydney Upton
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (31862, 0, 0, 0, 27654, 0, 8); -- Zane Bradford
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38102, 0, 0, 0, 27654, 0, 8); -- Elizabeth Van Talen
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (31861, 0, 0, 0, 27654, 0, 8); -- Lizabeth Cromwell
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38423, 0, 0, 0, 27654, 0, 8); -- Hannah Akeley
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (17628, 0, 0, 0, 27654, 0, 8); -- Algernon
+
+-- Questgivers
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (28494, 0, 0, 0, 27654, 0, 8); -- Velora Nitely
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (32021, 0, 0, 0, 27654, 0, 8); -- Genavie Callow
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (28491, 0, 0, 0, 27654, 0, 8); -- Patrick Garrett
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (91697, 0, 0, 0, 27654, 0, 8); -- Elenia Haydon
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (91698, 0, 0, 0, 27654, 0, 8); -- Fenstad Argyle
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (32051, 0, 0, 0, 27654, 0, 8); -- Raleigh Andrean
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (32053, 0, 0, 0, 27654, 0, 8); -- Keeper Bel'dugur
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (32056, 0, 0, 0, 27654, 0, 8); -- Jorah Annison
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (32024, 0, 0, 0, 27654, 0, 8); -- Andrew Brownell
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (32034, 0, 0, 0, 27654, 0, 8); -- Oran Snakewrithe
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (28496, 0, 0, 0, 27654, 0, 8); -- Mennet Carkad
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (41833, 0, 0, 0, 27654, 0, 8); -- Godrick Farsan
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (32041, 0, 0, 0, 27654, 0, 8); -- Andron Gant
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (32038, 0, 0, 0, 27654, 0, 8); -- Chemist Fuely
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (31904, 0, 0, 0, 27654, 0, 8); -- Chemist Cuely
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (31900, 0, 0, 0, 27654, 0, 8); -- Master Apothecary Faranell
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (32049, 0, 0, 0, 27654, 0, 8); -- Sharlindra
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (32052, 0, 0, 0, 27654, 0, 8); -- Bethor Iceshard
+
+
+-- Non Questgiver/Vendor
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38430, 0, 0, 0, 27654, 0, 8); -- Edrick Killian
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38429, 0, 0, 0, 27654, 0, 8); -- Mattie Alred
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (41831, 0, 0, 0, 27654, 0, 8); -- Selina Pickman
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (41830, 0, 0, 0, 27654, 0, 8); -- Davitt Hickson
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (41832, 0, 0, 0, 27654, 0, 8); -- Reginald Grimsford
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38100, 0, 0, 0, 27654, 0, 8); -- Hepzibah Sedgewick
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (31872, 0, 0, 0, 27654, 0, 8); -- Apothecary Katrina
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38090, 0, 0, 0, 27654, 0, 8); -- Apothecary Vallia
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (41844, 0, 0, 0, 27654, 0, 8); -- Helena Atwood
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38093, 0, 0, 0, 27654, 0, 8); -- Apothecary Lycanus
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (31882, 0, 0, 0, 27654, 0, 8); -- Lucian Fenner
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38097, 0, 0, 0, 27654, 0, 8); -- Gothard Winslow
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38101, 0, 0, 0, 27654, 0, 8); -- Susan Tillinghast
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38104, 0, 0, 0, 27654, 0, 8); -- Cedric Stumpel
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (31867, 0, 0, 0, 27654, 0, 8); -- Silas Zimmer
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38418, 0, 0, 0, 27654, 0, 8); -- Adrian Bartlett
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38063, 0, 0, 0, 27654, 0, 8); -- Winifred Kervin
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38434, 0, 0, 0, 27654, 0, 8); -- Marla Fowler
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38427, 0, 0, 0, 27654, 0, 8); -- Chloe Kurthas
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (31893, 0, 0, 0, 27654, 0, 8); -- Riley Walker
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (41836, 0, 0, 0, 27654, 0, 8); -- Andrew Hartnell
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38431, 0, 0, 0, 27654, 0, 8); -- Robert Gossom
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (31892, 0, 0, 0, 27654, 0, 8); -- Richard Van Brunt
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (17603, 0, 0, 0, 27654, 0, 8); -- Ganoosh
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38091, 0, 0, 0, 27654, 0, 8); -- Boyle
+
+-- Adding/Removing Gossip Options
+-- Vendors
+-- Louis Warren
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4557, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Louis');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4557, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Louis');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 4557;
+
+-- Timothy Weldon
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4559, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Timothy');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4559, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Timothy');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 4559;
+
+-- Timothy Weldon
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4560, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Walter');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4560, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Walter');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 4560;
+
+-- Lauren Newcomb
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4558, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Lauren');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4558, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Lauren');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 4558;
+
+-- Daniel Bartlett
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4561, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Daniel');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4561, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Daniel');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 4561;
+
+-- Tawny Grisette
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4554, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Tawny');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4554, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Tawny');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 4554;
+
+-- Thomas Mordan
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4562, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Thomas');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4562, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Thomas');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 4562;
+
+-- Eleanor Rusk
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4555, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Eleanor');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4555, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Eleanor');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 4555;
+
+-- Felicia Doan
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4775, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Felicia');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4775, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Felicia');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 4775;
+
+-- Ronald Burch
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4553, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Ronald');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4553, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Ronald');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 4553;
+
+-- Jeremiah Payson
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 8403, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Jeremiah');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 8403, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Jeremiah');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 8403;
+
+-- Nicholas Atwood
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4603, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Nicholas');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4603, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Nicholas');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 4603;
+
+-- Mirelle Tremayne
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4603, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Mirelle');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4603, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Mirelle');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 5819;
+
+-- Samuel Van Brunt
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4597, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Samuel');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4597, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Samuel');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 4597;
+
+-- Francis Eliot
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4601, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Francis');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4601, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Francis');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 4601;
+
+-- Benijah Fenner
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4602, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Benijah');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4602, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Benijah');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 4602;
+
+-- Geoffrey Hartwell
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4600, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Geoffrey');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4600, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Geoffrey');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 4600;
+
+-- Sarah Killian
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4599, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Sarah');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4599, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Sarah');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 4599;
+
+-- Abigail Sawyer
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4604, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Abigail');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4604, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Abigail');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 4604;
+
+-- Katrina Alliestar
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4615, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Katrina Alliestar');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4615, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Katrina Alliestar');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 4615;
+
+-- Thaddeus Webb
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4617, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Thaddeus');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4617, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Thaddeus');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 4617;
+
+-- Jonathan Chambers
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4590, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Jonathan');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4590, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Jonathan');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 4590;
+
+-- Gillian Moore
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5820, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Gillian');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5820, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Gillian');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 5820;
+
+-- Joseph Moore
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4589, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Joseph');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4589, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Joseph');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 4589;
+
+-- Ezekiel Graves
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4585, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Ezekiel');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4585, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Ezekiel');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 4585;
+
+-- Charles Seaton
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4569, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Charles');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4569, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Charles');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 4569;
+
+-- Nathaniel Steenwick
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4592, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Nathaniel');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4592, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Nathaniel');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 4592;
+
+-- Salazar Bloch
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4581, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Salazar');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4581, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Salazar');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 4581;
+
+-- Lucille Castleton
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4580, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Lucille');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4580, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Lucille');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 4580;
+
+-- Millie Gregorian
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4577, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Millie');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4577, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Millie');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 4577;
+
+-- Sheldon Von Croy
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5821, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Sheldon');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5821, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Sheldon');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 5821;
+
+-- Sydney Upton
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4570, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Sydney');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4570, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Sydney');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 4570;
+
+-- Zane Bradford
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5754, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Zane');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5754, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Zane');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 5754;
+
+-- Elizabeth Van Talen
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4587, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Elizabeth');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4587, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Elizabeth');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 4587;
+
+-- Lizabeth Cromwell
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4574, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Lizabeth');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4574, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Lizabeth');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 4574;
+
+-- Hannah Akeley
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4575, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Hannah');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4575, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Hannah');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 4575;
+
+-- Algernon
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4610, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Algernon');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4610, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Algernon');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 4610;
+
+-- Questgivers
+-- Velora Nitely
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 6411, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Velora');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 6411, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Velora');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 6411;
+
+-- Genavie Callow
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4486, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Genavie');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4486, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Genavie');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 4486;
+
+-- Patrick Garrett
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5651, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Patrick');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5651, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Patrick');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 5651;
+
+-- Elenia Haydon
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 16004, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Elenia');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 16004, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Elenia');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 16004;
+
+-- Fenstad Argyle
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 16108, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Fenstad');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 16108, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Fenstad');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 16108;
+
+-- Raleigh Andrean
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 2050, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Raleigh');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 2050, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Raleigh');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 2050;
+
+-- Keeper Bel'dugur
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 2934, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Beldugur');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 2934, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Beldugur');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 2934;
+
+-- Jorah Annison
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 6293, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Jorah');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 6293, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Jorah');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 6293;
+
+-- Andrew Brownell
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 2308, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Andrew');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 2308, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Andrew');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 2308;
+
+-- Oran Snakewrithe
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 7825, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Oran');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 7825, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Oran');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 7825;
+
+-- Mennet Carkad
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 6467, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Mennet');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 6467, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Mennet');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 6467;
+
+-- Godrick Farsan
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5693, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Godrick');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5693, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Godrick');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 5693;
+
+-- Andron Gant
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 6522, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Andron');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 6522, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Andron');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 6522;
+
+-- Chemist Fuely
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 10136, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Fuely');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 10136, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Fuely');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 10136;
+
+-- Chemist Fuely
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 8390, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Cuely');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 8390, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Cuely');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 8390;
+
+-- Master Apothecary Faranell
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 2055, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Faranell');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 2055, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Faranell');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 2055;
+
+-- Sharlindra
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 2227, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Shalindra');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 2227, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Shalindra');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 2227;
+
+-- Bethor Iceshard
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 1498, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Bethor');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 1498, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Bethor');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 1498;
+
+
+-- Non Questgiver/Vendor
+-- Edrick Killian
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5670, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Edrick');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5670, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Edrick');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 5670;
+
+-- Mattie Alred
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5668, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Mattie');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5668, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Mattie');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 5668;
+
+-- Selina Pickman
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5701, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Selina');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5701, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Selina');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 5701;
+
+-- Davitt Hickson
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5706, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Davitt');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5706, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Davitt');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 5706;
+
+-- Reginald Grimsford
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5707, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Reginald');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5707, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Reginald');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 5707;
+
+-- Hepzibah Sedgewick
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5747, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Hepzibah');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5747, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Hepzibah');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 5747;
+
+-- Apothecary Katrina
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5732, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Katrina');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5732, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Katrina');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 5732;
+
+-- Apothecary Vallia
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5731, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Vallia');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5731, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Vallia');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 5731;
+
+-- Helena Atwood
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5669, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Helena');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5669, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Helena');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 5669;
+
+-- Apothecary Lycanus
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5733, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Lycanus');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5733, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Lycanus');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 5733;
+
+-- Lucian Fenner
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 2799, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Lucien');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 2799, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Lucien');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 2799;
+
+-- Gothard Winslow
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 7297, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Gothard');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 7297, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Gothard');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 7297;
+
+-- Susan Tillinghast
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 2802, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Susan');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 2802, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Susan');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 2802;
+
+-- Cedric Stumpel
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5744, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Cedric');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5744, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Cedric');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 5744;
+
+-- Silas Zimmer
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4572, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Silas');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4572, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Silas');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 4572;
+
+-- Adrian Bartlett
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5704, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Adrian');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5704, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Adrian');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 5704;
+
+-- Winifred Kervin
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5703, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Winifred');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5703, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Winifred');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 5703;
+
+-- Victor Bartholemew
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5705, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Victor');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5705, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Victor');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 5705;
+
+-- Marla Fowler
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5657, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Marla');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5657, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Marla');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 5657;
+
+-- Chloe Kurthas
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5658, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Chloe');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5658, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Chloe');
+UPDATE `creature_template` SET `GossipMenuId`= 12858 WHERE `Entry`= 5658;
+
+-- Riley Walker
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5660, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Riley');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5660, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Riley');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 5660;
+
+-- Andrew Hartwell
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5659, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Andrew');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5659, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Andrew');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 5659;
+
+-- Robert Gossom
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5655, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Robert');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5655, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Robert');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 5655;
+
+-- Richard Van Brunt
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 5656, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Van Brunt');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 5656, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Van Brunt');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 5656;
+
+-- Ganoosh
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 11750, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Ganoosh');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 11750, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Ganoosh');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 11750;
+
+-- Boyle
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 4612, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Boyle');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 4612, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Boyle');
+UPDATE `creature_template` SET `GossipMenuId`= 12859 WHERE `Entry`= 4612;
+
+
+
+-- Existing Gossip
+-- Gordon Wendham, Harbinger Balthazad, Merill Pleasance, Christopher Drakul, Royal Overseer Bauhaus, Allesandro Luca, Ralston Farnsley, Estelle Gendry, Parqual Fintallas, Apothecary Zing
+-- Part of ongoing script Theresa, Gerard Abernathy, Joanna Whitehall, Leona Tharpe (Needs adding)
+-- Part of ongoing script Jezelle Pruitt, Sergeant Houser(Needs adding), Apothecary Keever(Needs adding)
+-- Brother Malach and Lysta part of ongoing script (needs adding)
+-- Samantha Shackleton - ongoing script
+-- Edward Remington will need adding
+-- Mara Rennick, Alyssa Blaye, Eldin Partridge, Travis Bosk faction 1154
+-- Carendin Halgar, Sergeant Rutger faction 83
+-- Edward, Tyler faction 118
+-- Theodore Griffs faction 35
+-- Thersa Windsong is poisoned and not thinking about love

--- a/Updates/Undercity Guardians.sql
+++ b/Updates/Undercity Guardians.sql
@@ -1,0 +1,129 @@
+-- Adding Love is in the Air Aura
+
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (17669, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (28481, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (28485, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (28486, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (28487, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (28488, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (28489, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (28490, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (33823, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (33831, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (34102, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (34103, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (34104, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (34105, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (34106, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38296, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38297, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38298, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38299, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38301, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38302, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (38305, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (39019, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (39020, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (39022, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (39023, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (39024, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (39025, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (39026, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (41884, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (41887, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (41888, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (41889, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (41890, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (41891, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (41892, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (41956, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (41960, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (41961, 0, 0, 0, 27654, 0, 8);
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (41964, 0, 0, 0, 27654, 0, 8);
+
+-- Changing standard gossip to display only outside of event
+UPDATE `gossip_menu` SET `condition_id`= 501 WHERE `entry`= 2849 and `text_id`= 3543;
+
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (2849, 8270, 0, 507);
+
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (2849, 14, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 0, 0, 0, NULL, 528);
+
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (2849, 8282, 0, 508);
+
+-- Adding perfume + cologne npc text
+INSERT INTO `npc_text` (`ID`, `text0_0`, `text0_1`, `lang0`, `prob0`, `em0_0`, `em0_1`, `em0_2`, `em0_3`, `em0_4`, `em0_5`, `text1_0`, `text1_1`, `lang1`, `prob1`, `em1_0`, `em1_1`, `em1_2`, `em1_3`, `em1_4`, `em1_5`, `text2_0`, `text2_1`, `lang2`, `prob2`, `em2_0`, `em2_1`, `em2_2`, `em2_3`, `em2_4`, `em2_5`, `text3_0`, `text3_1`, `lang3`, `prob3`, `em3_0`, `em3_1`, `em3_2`, `em3_3`, `em3_4`, `em3_5`, `text4_0`, `text4_1`, `lang4`, `prob4`, `em4_0`, `em4_1`, `em4_2`, `em4_3`, `em4_4`, `em4_5`, `text5_0`, `text5_1`, `lang5`, `prob5`, `em5_0`, `em5_1`, `em5_2`, `em5_3`, `em5_4`, `em5_5`, `text6_0`, `text6_1`, `lang6`, `prob6`, `em6_0`, `em6_1`, `em6_2`, `em6_3`, `em6_4`, `em6_5`, `text7_0`, `text7_1`, `lang7`, `prob7`, `em7_0`, `em7_1`, `em7_2`, `em7_3`, `em7_4`, `em7_5`) VALUES (8303, 'I\'d talk to you if you smelled better. How about cologne? Maybe perfume? ', 'I\'d talk to you if you smelled better. How about cologne? Maybe perfume? ', 0, 1, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0, '', '', 0, 0, 0, 0, 0, 0, 0, 0);
+
+-- No Perfume or Cologne gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (2849, 8303, 0, 530);
+
+-- Cast Valentine(26924) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (284901, 0, 15, 26924, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Undercity Guardian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (284901, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (2849, 8296, 0, 518);
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (2849, 8291, 0, 524);
+
+UPDATE `gossip_menu_option` SET `action_script_id`= 284901 WHERE `menu_id`= 2849 AND `id`= 14;
+
+-- Seekers
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (32073, 0, 0, 0, 27654, 0, 8); -- Cromwell
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (32074, 0, 0, 0, 27654, 0, 8); -- Nahr
+INSERT INTO `game_event_creature_data` (`guid`, `entry_id`, `modelid`, `equipment_id`, `spell_start`, `spell_end`, `event`) VALUES (32072, 0, 0, 0, 27654, 0, 8); -- Thompson
+
+-- UC Seeker Thompson template - Gossip Menu + Options
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12861, 8270, 0, 507);
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12861, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 1286101, 0, 0, NULL, 517);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12861, 8283, 0, 508);
+-- No Cologne gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12861, 8287, 0, 519);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12861, 8296, 0, 518);
+-- Cast Valentine(26924) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1286101, 0, 15, 26924, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Undercity Guardian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1286101, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12861, 8291, 0, 524);
+
+-- UC Seeker Cromwell + Nahr template - Gossip Menu + Options
+-- Love Tokens
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12862, 8270, 0, 507);
+-- Adding token menu option
+INSERT INTO `gossip_menu_option` (`menu_id`, `id`, `option_icon`, `option_text`, `option_id`, `npc_option_npcflag`, `action_menu_id`, `action_poi_id`, `action_script_id`, `box_coded`, `box_money`, `box_text`, `condition_id`) VALUES (12862, 1, 0, 'Here, I\'d like to give you this token of my love.', 1, 1, 0, 0, 1286201, 0, 0, NULL, 523);
+-- Heartbroken gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12862, 8283, 0, 508);
+-- No Perfume gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12862, 8289, 0, 520);
+-- Already Adored Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12862, 8296, 0, 518);
+-- Cast Valentine(26924) in response to receiving love token
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1286201, 0, 15, 26924, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Cast valentine Undercity Guardian on player');
+INSERT INTO `dbscripts_on_gossip` (`id`, `delay`, `command`, `datalong`, `datalong2`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (1286201, 0, 14, 27741, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Love is in the Air Aura');
+
+-- No Token Gossip
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES (12862, 8291, 0, 524);
+
+-- Adding Gossip options to turn on during event and off after
+-- Seeker Cromwell
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 14402, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Cromwell');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 14402, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Cromwell');
+UPDATE `creature_template` SET `GossipMenuId`= 12862 WHERE `Entry`= 14402;
+
+-- Seeker Nahr
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 14403, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Nahr');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 14403, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Nahr');
+UPDATE `creature_template` SET `GossipMenuId`= 12862 WHERE `Entry`= 14403;
+
+-- Seeker Thompson
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27654, 0, 29, 1, 1, 0, 14404, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Add Gossip to Thompson');
+INSERT INTO `dbscripts_on_spell` (`id`, `delay`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `comments`) VALUES (27657, 0, 29, 1, 2, 0, 14404, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 'Remove Gossip from Thompson');
+UPDATE `creature_template` SET `GossipMenuId`= 12861 WHERE `Entry`= 14404;


### PR DESCRIPTION
This pull request aims to fix several issues that currently exist with the Love is in the Air festival on Cmangos Classic.  Currently the state of the event provides no functionality associated with npc interactions, quests and items to complete any activities that comprise this event. Specificallt this includes:

1. Innkeepers do not stock any event items or provide any information on the event to players
2. Guard and civilian npc do not provide gossip interactions to obtain any of the necessary items for the event.
3. Kwee is not spawned anywhere
4. Questline is broken and does not progress correctly.
5. Final quest hand-in is not scripted
6. Spells/items not functional(nf)/behaviour issues i.e. Candy bag(nf), silver shafted arrow(nf), love fool(follows player instead of remaining stationary)

This PR aims to correct these issues or highlight issues unable to be corrected.  Along with screenshots, web pages and videos as refences, the following assumptions have been made:

Buff/debuff priority: Love token > perfume/cologne > heartbroken

City gifts are given based on faction rather than race.  Some npcs have a city faction different than one associated with their race.  e.g. npc with dwarf model has stormwind faction or tauren model with orgrimmar faction.  These are uncommon and for the most part the model will align with the faction of the npc.

There wasn't enough evidence to conclusively assign civilian and guard gossips so some of this is guesswork.  Missing tauren and troll racial gossips need to be located probably.  Placeholders (tauren, troll, goblin) have been put in place until better information is found. Others races have been matched to a reasonably obvious gossip that characterises the particular race.

Heartbroken to gift ration set at 1:6.  Can change this to another ratio for exact data.

Civilians have been classified as vendors, questgivers and npcs that have no known purpose.  Trainers and npcs with specific gossips were not candidates for gift giving duties. This due to having to assign a complete gossip menu for each of these as well as obscuring the original gossip which could contain necessary information for players be they new or otherwise.  Stormwind was an exception where generic gossip was present for all vendors in a specific quarter.  In this case these vendors were candidates for civilian gift giving. Npcs known to involved with scripts were also not considered candidates.

Guards were divided into two groups, those that were of one gender(Dwarves, Sentinels) or no gender(Undercity) and those with two genders(Stormwind, Thunderbluff and Orgrimmar).  One gender guards gossips could be handled through the DB whereas the two gender guards had to be handled through SD2.  Npcs unlike players, don't have gender.  They only have modelids that show gender.  There is no DB condition to check for modelid and so the gossip menus for these two gendered guards had to be manually scripted in sd2 incorporating the modelid condition check for offering a male or female gossip response.

There various valentine spells (8) were arbitrarily assigned as follows:

1 spell for each city guards
1 spell covering alliance civilians
1 spell covering horde civilians

The two questlines were also corrected with dependencies and next quests properly organised.  However, the final quest given by the fragrant cauldron was unavailable(gm mode shows available) having met the correct requirements so a suspected incorrect lock value for the gameobject could be the problem in fixing this issue. Scripting of The Source Revealed quests between Stafford and Annalise Lerent has also been implemented.

Due to lack of any exact data Kwee spawns were estimated from screenshots.
Heart Candy spell was added to core.

References:
http://world-of-warcraft.alteredgamer.com/wow-achievements/45389-world-of-warcraft-holiday-event-achievements-love-is-in-the-air/#imgn_0
http://casualwow.blogspot.com.au/2007/02/love-is-in-air-decorations.html
http://casualwow.blogspot.com.au/2007/02/love-is-in-air-two-things-i-didnt-know.html
https://casualwow.blogspot.com.au/2007/02/love-is-in-air-get-thee-to-kwee.html?m=0
http://www.techrepublic.com/pictures/making-love-in-the-world-of-warcraft/
http://wowwiki.wikia.com/wiki/Strange_Winged_Goblin
http://www.wowhead.com/npc=22239/strange-winged-goblin#comments
https://www.wow-freakz.com/npc_finder.php?npc=22239&name=strange-winged-goblin
https://web.archive.org/web/20070213054629/http://www.wowwiki.com/Love_is_in_the_Air
http://wowwiki.wikia.com/wiki/Love_is_in_the_Air_2009
http://www.wowhead.com/quest=8993/gift-giving#comments
http://casualwow.blogspot.com.au/2007/02/there-is-no-love-in-exodar-or.html
https://www.engadget.com/2007/02/13/guards-bugged-in-silvermoon-city/
http://wow.gamepedia.com/Pledge_of_Adoration
http://wow.gamepedia.com/Pledge_of_Friendship
http://wow.gamepedia.com/Gift_of_Adoration
http://wow.gamepedia.com/Gift_of_Friendship
http://wowwiki.wikia.com/wiki/Stormwind_Guard%27s_Card
http://wowwiki.wikia.com/wiki/Undercity_Guardian
http://wow.gamepedia.com/Guardian%27s_Moldy_Card
https://www.engadget.com/2009/02/10/the-overachiever-completing-fool-for-love/ Coldara Dean gossip photo
http://www.wowhead.com/quest=8980/zinges-assessment -- wowwiki, wowpedia wrong.  Not a choice of rewards. same for 9025.
http://www.pcgames.de/World-of-Warcraft-Wrath-of-the-Lich-King-Spiel-42979/Specials/World-of-Warcraft-Liebe-liegt-in-der-Luft-704467/galerie/1245983/
http://www.buffed.de/World-of-Warcraft-Spiel-42971/Videos/Wow-Show-13-797600/
https://wow.gamepedia.com/Bouquet_of_Red_Roses
https://www.engadget.com/2007/02/13/sex-in-the-undercity-a-guide-to-finding-love-in-azeroth/