### PR TITLE
Fixed creatures dropping Scarlet Cannonball.

### DIFF
--- a/Updates/2138_i12973_remove_drops_from_creature.sql
+++ b/Updates/2138_i12973_remove_drops_from_creature.sql
@@ -1,0 +1,5 @@
+-- Thanks @AnonXS for confirming.
+
+-- https://github.com/TrinityCore/TrinityCore/commit/145b9c05d7119d28002f0b87fd6f46eb19d056c1#diff-03bd12f55a38e268d4353ec63731468e
+-- None of the creatures should drop Scarlet Cannonball
+DELETE FROM `creature_loot_template` WHERE `item`=12973;


### PR DESCRIPTION
Currently creatures are dropping Scarlet Cannonball even though it should be looted from a gameobject instead.

Thanks @AnonXS for confirming.

https://github.com/TrinityCore/TrinityCore/commit/145b9c05d7119d28002f0b87fd6f46eb19d056c1#diff-03bd12f55a38e268d4353ec63731468e
None of the creatures should drop Scarlet Cannonball