### PR TITLE
Fix item drop rates and stop scaling Arcane Shot with ranged attack power

### DIFF
--- a/Updates/2256_drop_rates.sql
+++ b/Updates/2256_drop_rates.sql
@@ -1,4 +1,4 @@
 /* Fix ridiculous drop rates for Simple Bands and Gypsy Cloak from Burning Blade mobs */
 UPDATE creature_loot_template SET chanceorquestchance=0.359 WHERE entry=3197 AND item=9744;
-UPDATE creature_loot_template SET chanceorquestchance=0.666 WHERE entry=3197 AND item=9745;
+UPDATE creature_loot_template SET chanceorquestchance=0.666 WHERE entry=3197 AND item=9754;
 

--- a/Updates/2256_drop_rates.sql
+++ b/Updates/2256_drop_rates.sql
@@ -1,0 +1,4 @@
+/* Fix ridiculous drop rates for Simple Bands and Gypsy Cloak from Burning Blade mobs */
+UPDATE creature_loot_template SET chanceorquestchance=0.359 WHERE entry=3197 AND item=9744;
+UPDATE creature_loot_template SET chanceorquestchance=0.666 WHERE entry=3197 AND item=9745;
+

--- a/Updates/2257_drop_rates.sql
+++ b/Updates/2257_drop_rates.sql
@@ -1,0 +1,3 @@
+/* Fix Westfall Crawlers not dropping specific items */
+insert into creature_loot_template values (830, 2087, 0.4, 0, 1, 1, 0, 'Hard Crawler Carapace');
+insert into creature_loot_template values (831, 2088, 3.9, 0, 1, 1, 0, 'Long Crawler Limb');

--- a/Updates/2258_arcane_shot.sql
+++ b/Updates/2258_arcane_shot.sql
@@ -1,0 +1,2 @@
+/* Fix Arcane Shot scaling with ranged AP (it shouldn't) */
+UPDATE spell_bonus_data SET ap_bonus = 0 WHERE entry = 3044;


### PR DESCRIPTION
This PR fixes 3 issues I found:

* Burning Blade Apprentice mobs were dropping Gypsy Cloak and Simple Bands much too often (45% and 72% of the time, respectively). I set them to the average drop rate for those items.
* Mob-specific loot (Hard Crawler Carapace and Long Crawler Limb) for Sand Crawler and Sea Crawler mobs was not implemented. I gave them the drop rates I found on Thottbot: 
https://web.archive.org/web/20071228072635/http://thottbot.com/i2087
https://web.archive.org/web/20071228072635/http://thottbot.com/i2088
* Arcane Shot should not scale with RAP, only spellpower, as implied here: http://wowwiki.wikia.com/wiki/Arcane_Shot?oldid=562762
> Since Patch 2.0.1 Arcane Shot scales with the Hunter's Ranged Attack Power ...