### PR TITLE
Update ArmorMultiplier of Warlock pets.

### DIFF
--- a/Updates/ArmorMultiplier_Warlock_pets.sql
+++ b/Updates/ArmorMultiplier_Warlock_pets.sql
@@ -1,0 +1,4 @@
+-- Update ArmorMultiplier of Warlock pets. Current ArmorMultiplier value of -1 leads to negative armor leading to an armor value of 0.
+UPDATE `creature_template`
+SET `ArmorMultiplier` = 1
+WHERE `Entry` IN (416, 417, 1860, 1863);


### PR DESCRIPTION
Update ArmorMultiplier of Warlock pets. Current ArmorMultiplier value of -1 leads to negative armor leading to an armor value of 0.

https://github.com/cmangos/issues/issues/1778