### PR TITLE
Update 2329_jungle_toad.sql

### DIFF
--- a/Updates/2329_jungle_toad.sql
+++ b/Updates/2329_jungle_toad.sql
@@ -1,5 +1,5 @@
 -- Add target NPC 15010 (Jungle Toad) for spell 24062 (Explode Toad)
 -- Thanks @Phatcat for his help and testing
 -- Closes #148
-DELETE FROM spell_script_target WHERE entry=24062
-INSERT INTO spell_script_target VALUES (24062, 1, 15010, 0);
+DELETE FROM spell_script_target WHERE entry=24062;
+INSERT INTO spell_script_target (entry, type, targetEntry, inverseEffectMask) VALUES (24062, 1, 15010, 0);


### PR DESCRIPTION
Original 2329 patch didn't include table structure for SQL syntax and was missing a semicolon.