### PR TITLE
Give CREATURE_EXTRA_FLAG_INVISIBLE flag to 15214.

### DIFF
--- a/Updates/2346_make_invisible_stalker_invisible.sql
+++ b/Updates/2346_make_invisible_stalker_invisible.sql
@@ -1,0 +1,1 @@
+UPDATE `creature_template` SET `ExtraFlags` = 130 WHERE `Entry` = 15214;


### PR DESCRIPTION
Currently this creature is visible in Brill (there are other spawns elsewhere too) ruining immersion. I don't know if this is the correct way to deal with it but to me it should either be invisible or not spawned at all.