### PR TITLE
Fix for incorrectly scaled Imp Minion guardians

### DIFF
--- a/Updates/2573_imp_minions.sql
+++ b/Updates/2573_imp_minions.sql
@@ -1,0 +1,2 @@
+-- set armormultiplier to 0 for Imp Minion to use CLS
+UPDATE creature_template SET ArmorMultiplier=0 WHERE entry = 12922;


### PR DESCRIPTION
Imp Minion Guardians were not correctly scaled and ended up with 3 times
as much health as their handler.
This was due to not using the CLS system for calculating stats, but
instead falling back to the old system with linear scaling.
This commit changes the "ArmorMultiplier" from -1 to 0 for Imp Minions,
causing the CLS system to be used instead.