### PR TITLE
Allow Alliance Warlocks to pick up Dreadsteed quest

### DIFF
--- a/Updates/3068_dreadsteed_quest.sql
+++ b/Updates/3068_dreadsteed_quest.sql
@@ -1,0 +1,2 @@
+-- Allow Alliance Warlocks to pick up quest "Mor-zul Bloodbringer"
+UPDATE quest_template SET RequiredRaces = 0 WHERE entry = 7562;


### PR DESCRIPTION
Quest 7562 (Mor'zul Bloodbringer) was limited to only Horde characters (`RequiredRaces` was set to 178). Quest should be available to Alliance Warlocks as well.

I named the branch after the wrong steed, but the commit fixes the quest for the right steed.