### PR TITLE
Create 3374_dbscripts_gossip_teleports.sql

### DIFF
--- a/Updates/3374_dbscripts_gossip_teleports.sql
+++ b/Updates/3374_dbscripts_gossip_teleports.sql
@@ -1,0 +1,8 @@
+#NPC https://classic.wowhead.com/npc=11800/silva-filnaveth
+UPDATE `dbscripts_on_gossip` SET `command`=15,`datalong`='27998' WHERE `id`=4041;
+#NPC https://classic.wowhead.com/npc=11798/bunthen-plainswind
+UPDATE `dbscripts_on_gossip` SET `command`=15,`datalong`='28001' WHERE `id`=4042;
+#NPC https://classic.wowhead.com/npc=17209/william-kielar
+UPDATE `dbscripts_on_gossip` SET `command`=15,`datalong`='29931' WHERE `id`=737901;
+UPDATE `dbscripts_on_gossip` SET `command`=15,`datalong`='29934' WHERE `id`=737902;
+UPDATE `dbscripts_on_gossip` SET `command`=15,`datalong`='29994' WHERE `id`=737903;

--- a/Updates/3374_druid_moonblade_teleports.sql
+++ b/Updates/3374_druid_moonblade_teleports.sql
@@ -1,2 +1,0 @@
-UPDATE `dbscripts_on_gossip` SET `command`=15,`datalong`='27998' WHERE `id`=4041;
-UPDATE `dbscripts_on_gossip` SET `command`=15,`datalong`='28001' WHERE `id`=4042;

--- a/Updates/3374_druid_moonblade_teleports.sql
+++ b/Updates/3374_druid_moonblade_teleports.sql
@@ -1,0 +1,2 @@
+UPDATE `dbscripts_on_gossip` SET `command`=15,`datalong`='27998' WHERE `id`=4041;
+UPDATE `dbscripts_on_gossip` SET `command`=15,`datalong`='28001' WHERE `id`=4042;


### PR DESCRIPTION
Fix for https://github.com/cmangos/issues/issues/2352

The Legacy state in fresh DB:
{
	"table": "dbscripts_on_gossip",
	"rows":
	[
		{
			"id": 4041,
			"delay": 0,
			"priority": 0,
			"command": 30, ??
			"datalong": 315,
			"datalong2": 0,
			"datalong3": 0,
			"buddy_entry": 0,
			"search_radius": 0,
			"data_flags": 0,
			"dataint": 0,
			"dataint2": 0,
			"dataint3": 0,
			"dataint4": 0,
			"x": 0,
			"y": 0,
			"z": 0,
			"o": 0,
			"condition_id": 0,
			"comments": "fly to Rut'theran Village"
		},
		{
			"id": 4042,
			"delay": 0,
			"priority": 0,
			"command": 30,
			"datalong": 316,
			"datalong2": 0,
			"datalong3": 0,
			"buddy_entry": 0,
			"search_radius": 0,
			"data_flags": 0,
			"dataint": 0,
			"dataint2": 0,
			"dataint3": 0,
			"dataint4": 0,
			"x": 0,
			"y": 0,
			"z": 0,
			"o": 0,
			"condition_id": 0,
			"comments": "fly to Thunder Bluff"
		}
	]
}


The Legacy doc declare at https://github.com/cmangos/issues/wiki/spell_template:

30 	SCRIPT_COMMAND_SEND_TAXI_PATH 	Sends a player on a give taxi path. 

But we have to use 

15 	SCRIPT_COMMAND_CAST_SPELL 	Casts a spell.

with the spells https://classic.wowhead.com/spell=27998/flight-path && https://classic.wowhead.com/spell=28001/flight-path