### PR TITLE
Add 3377_azuregos_attackable_on_event

### DIFF
--- a/Updates/3377_azuregos_attackable_on_event.sql
+++ b/Updates/3377_azuregos_attackable_on_event.sql
@@ -1,0 +1,1 @@
+REPLACE INTO `dbscripts_on_gossip` (`id`, `command`, `datalong`, `search_radius`, `comments`) VALUES ('15000', '4', '8', '0', 'Set flag attackable on Azuregos');


### PR DESCRIPTION
https://github.com/cmangos/issues/issues/2501

Before that purpose, the menu is unchanged and not closed and the status of azuregos is still unattackable and he start to attack you.
After menu closed and azuregos start on event and be attackable.

See you soon cMangos