### PR TITLE
Add gossip text for non-herbalists for NPC Tannysa

### DIFF
--- a/Updates/3735_npc_tannysa_gossip_text.sql
+++ b/Updates/3735_npc_tannysa_gossip_text.sql
@@ -1,0 +1,4 @@
+DELETE FROM `gossip_menu` WHERE `entry`=643 AND `text_id`=1202;
+INSERT INTO `gossip_menu` (`entry`, `text_id`, `script_id`, `condition_id`) VALUES
+(643, 1202, 0, 0);
+


### PR DESCRIPTION
[Tannysa](https://classic.wowhead.com/npc=5566/tannysa) should say "I hope that your interruption is for a good cause, I was in the middle of some important work." if you talk to her while you don't have Herbalism. Right now she just says the default "Greetings $N".

To test:
- .go creature id 5566
- Talk to her.

Classic only. TBC has the opposite problem, she's missing the text for Herbalists. I'll make a PR for it. WotLK has both.