### PR TITLE
Fix stats for Warlock pets at level 60.

### DIFF
--- a/Updates/3737_warlock_pet_levelstats_60.sql
+++ b/Updates/3737_warlock_pet_levelstats_60.sql
@@ -1,0 +1,5 @@
+UPDATE `pet_levelstats` SET `str`=129, `agi`=85, `sta`=234, `inte`=70, `spi`=150 WHERE `creature_entry`=1863 AND `level`=60; -- Succubus
+UPDATE `pet_levelstats` SET `hp`=769, `agi`=35, `sta`=86, `spi`=260 WHERE `creature_entry`=416 AND `level`=60; -- Imp
+UPDATE `pet_levelstats` SET `sta`=234 WHERE `creature_entry`=1860 AND `level`=60; -- Voidwalker
+UPDATE `pet_levelstats` SET `hp`=2320, `armor`=2317, `str`=129, `agi`=85, `sta`=234, `inte`=70, `spi`=150 WHERE `creature_entry`=417 AND `level`=60; -- Felhunter
+


### PR DESCRIPTION
Values are taken from the Season of Mastery BWL Classic Era PTR. Made sure there were no buffs interfering with the stats: no Imp's Blood Pact, no bonus from tier sets, no bonus from talents.

Note that those are only the values for level 60. This means that for statistics that were wildly wrong like Intellect and Spirit, you'll see a diminution from 59 (Succubus, 103 Intellect) to 60 (Succubus, 70 Intellect). I don't know how to fix that, as I haven't been able to find any info on what stats they should have below 60.