### PR TITLE
The quest An Easy Pickup is only available if the quest Arcane Runes is taken, complete or rewarded

### DIFF
--- a/Updates/3744_an_easy_pickup_conditions.sql
+++ b/Updates/3744_an_easy_pickup_conditions.sql
@@ -1,0 +1,7 @@
+UPDATE `quest_template` SET `RequiredCondition`=1603 WHERE `entry`=3450;
+DELETE FROM `conditions` WHERE `condition_entry` IN (1601, 1602, 1603);
+INSERT INTO `conditions` (`condition_entry`, `type`, `value1`, `value2`, `value3`, `value4`, `flags`, `comments`) VALUES
+(1601, 9, 3449, 0, 0, 0, 0, "Quest ID 3449 Taken"),
+(1602, 8, 3449, 0, 0, 0, 0, "Quest ID 3449 Rewarded"),
+(1603, -2, 1601, 1602, 0, 0, 0, "Quest ID 3449 Taken OR Quest ID 3449 Rewarded");
+


### PR DESCRIPTION
In order to accept the quest [An Easy Pickup](https://classic.wowhead.com/quest=3450/an-easy-pickup), you must have the quest [Arcane Runes](https://classic.wowhead.com/quest=3449/arcane-runes) either in your quest log (taken or complete) or rewarded.

Proof:

https://user-images.githubusercontent.com/99603810/155219148-d1f5f3fb-1d22-44d5-adcb-68db0eadfff4.mp4

I picked condition IDs that are free on all three databases.


To test:
Be at level 45.
.go creature id 8507
.quest add 3448
Turn 3448 in, accept the other two.