### PR TITLE
Add missing emote for text used by NPC Balos Jacken

### DIFF
--- a/Updates/3744_missing_emote_for_balos_jacken.sql
+++ b/Updates/3744_missing_emote_for_balos_jacken.sql
@@ -1,0 +1,2 @@
+UPDATE `broadcast_text` SET `EmoteID1`=1 WHERE `Id`=1756;
+


### PR DESCRIPTION
From https://github.com/cmangos/wotlk-db/pull/403/files#diff-af14bbfeeeee8d327edbd2b9ed76373389c3a3002d006b8205416ad2a8f2ab4cR43802, did not make it because that PR was merged after the recent deprecation of creature_ai_texts.