### PR TITLE
Alterac Valley tweaks

### DIFF
--- a/Updates/9999_alterac_valley_fixes.sql
+++ b/Updates/9999_alterac_valley_fixes.sql
@@ -1,0 +1,7 @@
+-- Fix Snowfall GY Spirit Guide linked to wrong GY
+UPDATE `creature_battleground` SET `event2`='3' WHERE  `guid`=150390; -- Horde
+UPDATE `creature_battleground` SET `event1`='3' WHERE  `guid`=150383; -- Alliance
+-- Fix Horde Cave Spirit Guide being in tbc + position (horde entrance was moved in 2.4), coords from vmangos
+UPDATE `creature` SET `position_x`='-818.557', `position_y`='-619,255', `position_z`='54,0388', `orientation`='2,16456' WHERE  `guid`=150395;
+-- Fix Snowfall Alliance Contested flag not being usable, meaning as a horde you had to wait till GY is taken
+UPDATE `gameobject_template` SET `flags`=`flags` & ~1 WHERE `entry`=179286; -- flag 1 (uninteractable) prevents from using it


### PR DESCRIPTION
Alterac Valley may have many issues db-wise, but this PR is not about fixing them all, rather some of most obvious ones I came across:
 - Snowfall GY Spirit guides being assigned to a wrong bg event meaning that if you get teleported to it you can't ress
 - Horde Cave Spirit Guide was spawned under the map in patch 2.4+ position meaning that horde can never ress if all GYs are taken by alliance or if you die near cave
 - Snowfall Alliance Contested Banner had GO flag = 1 (whole mask = 65). It made it uninteractable meaning Horde could not prevent Alliance capturing GY and had to wait for it to become owned by Alliance and only then use Alliance Banner to try to capture it