### PR TITLE
[3753] Remove wrong script from quest Sarkoth.

### DIFF
--- a/Updates/3753_quest_sarkoth_remove_wrong_script.sql
+++ b/Updates/3753_quest_sarkoth_remove_wrong_script.sql
@@ -1,0 +1,3 @@
+UPDATE `quest_template` SET `CompleteScript`=0 WHERE `entry`=790;
+DELETE FROM `dbscripts_on_quest_end` WHERE `id`=790;
+


### PR DESCRIPTION
Backport missing part of https://github.com/cmangos/tbc-db/commit/6edbb93cb8766c8634600ad39178e2a639408d8e

The quest [Sarkoth](https://classic.wowhead.com/quest=790/sarkoth) (entry: 790) currently has a wrong end script that changes his standstate from dead to kneel and then back to dead.

There actually is a script related to that NPC, and it's already scripted correctly (the on-start script for [Sarkoth](https://classic.wowhead.com/quest=804/sarkoth) (entry: 804)).

Basically the event was scripted twice, once on the end of the first step and once on the start of the second step. Only the second script is correct, the first should not exist.

To test:
- Create a Horde character.
- .go creature 3287
- .quest add 790
- .quest complete 790
- Turn in the quest, wait for the event, accept the new quest, wait for the event.
