### PR TITLE
Add known interaction pause timers and remove workaround removals of gossip flag from Private Thorsen and Short John Mithril

### DIFF
--- a/Updates/3760_interaction_pause_timer.sql
+++ b/Updates/3760_interaction_pause_timer.sql
@@ -1,0 +1,12 @@
+-- Remove gossip flag changes from Private Thorsen
+DELETE FROM `dbscripts_on_creature_movement` WHERE `command`=29 AND `id` IN (73801, 73807);
+
+-- Remove gossip flag changes from Short John Mithril
+DELETE FROM `dbscripts_on_creature_movement` WHERE `command`=29 AND `id` IN (1450801, 1450803);
+UPDATE `creature_movement_template` SET `Comment`='Short John Mithril - Yell 1' WHERE `Entry`=14508 AND `Point`=1;
+UPDATE `creature_movement_template` SET `Comment`='Short John Mithril - Run Off, MovementType 0' WHERE `Entry`=14508 AND `Point`=35;
+
+UPDATE `creature_template` SET `InteractionPauseTimer`=0 WHERE `Entry` IN (738, 14508); -- Private Thorsen, Short John Mithril
+UPDATE `creature_template` SET `InteractionPauseTimer`=5000 WHERE `Entry`=9077; -- Warlord Goretooth
+UPDATE `creature_template` SET `InteractionPauseTimer`=30000 WHERE `Entry`=11317; -- Jinar'Zillen
+


### PR DESCRIPTION
What it says on the tin. Private Thorsen and [Short John Mithril](https://github.com/cmangos/mangos-classic/pull/477#issuecomment-1059494248) had gossip flag removed on waypoint movement to prevent people from stopping them, but they have interactiontimer = 0 so they won't stop.

To test:
.go creature 14508
.event start 16
Talk with him.

This NPC is TBC only, adding it here for eventual backporting of this and https://github.com/cmangos/mangos-classic/pull/477:
```sql
UPDATE `creature_template` SET `InteractionPauseTimer`=3000 WHERE `Entry`=17246; -- "Cookie" McWeaksauce (TBC only)
```

WotLK repository is missing https://github.com/cmangos/tbc-db/commit/b676543aef3bbd4cdf1cbcbba00fe5a83340c934 so changes related to Short John Mithril won't do anything.