### PR TITLE
Fix start time for the Gurubashi Arena Run event

### DIFF
--- a/Updates/3760_gurubashi_arena_run_start_time.sql
+++ b/Updates/3760_gurubashi_arena_run_start_time.sql
@@ -1,0 +1,2 @@
+UPDATE `game_event_time` SET `start_time`='2007-08-04 15:01:00' WHERE `entry`=16;
+


### PR DESCRIPTION
Short John Mithril started his yell and waypoint movement at 06:01 for me. In the current implementation the event starts earlier, as of https://github.com/cmangos/tbc-db/commit/b676543aef3bbd4cdf1cbcbba00fe5a83340c934.

https://user-images.githubusercontent.com/99603810/156887390-a0cecbbb-70ff-4344-9b63-fa6fe5d2276d.mp4

Valid for Vanilla, TBC and WotLK.