### PR TITLE
Add missing instance_template entries for battlegrounds, PvP instances in Orgrimmar/Stormwind and Deeprun Tram

### DIFF
--- a/Updates/3760_instance_template.sql
+++ b/Updates/3760_instance_template.sql
@@ -1,0 +1,9 @@
+DELETE FROM `instance_template` WHERE `map` IN (30, 369, 449, 450, 489, 529);
+INSERT INTO `instance_template` (`map`, `parent`, `levelMin`, `levelMax`, `maxPlayers`, `reset_delay`, `ghostEntranceMap`, `ghostEntranceX`, `ghostEntranceY`, `ScriptName`, `mountAllowed`) VALUES
+(30, 0, 0, 0, 0, 0, 0, 0, 0, '', 0),
+(369, 0, 0, 0, 0, 0, 0, 0, 0, '', 0),
+(449, 0, 0, 0, 0, 0, 0, 0, 0, '', 0),
+(450, 0, 0, 0, 0, 0, 0, 0, 0, '', 0),
+(489, 0, 0, 0, 0, 0, 0, 0, 0, '', 0),
+(529, 0, 0, 0, 0, 0, 0, 0, 0, '', 0);
+


### PR DESCRIPTION
https://github.com/cmangos/mangos-classic/pull/474 and https://github.com/cmangos/mangos-classic/commit/a9fd71636be7c6ff10067df0dc0472849e26a9a9 (thanks for both fixes!) exposed the need for an entry in instance_template for all instanced maps: battlegrounds, the PvP barracks and Deeprun Tram.

Without this, the server crashes when you die and release spirit inside one of those locations.