### PR TITLE
Improve end event for quest The Defias Brotherhood (166)

### DIFF
--- a/Updates/3760_the_defias_brotherhood_end_event.sql
+++ b/Updates/3760_the_defias_brotherhood_end_event.sql
@@ -1,0 +1,12 @@
+DELETE FROM `dbscript_random_templates` WHERE `id`=20;
+INSERT INTO `dbscript_random_templates` (`id`, `type`, `target_id`, `chance`, `comments`) VALUES
+(20, 0, 197, 0, 'Gryan Stoutmantle - Random On Quest Completion Texts'),
+(20, 0, 198, 0, 'Gryan Stoutmantle - Random On Quest Completion Texts'),
+(20, 0, 199, 0, 'Gryan Stoutmantle - Random On Quest Completion Texts');
+
+DELETE FROM `dbscripts_on_quest_end` WHERE `id`=166;
+INSERT INTO `dbscripts_on_quest_end` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
+(166, 1000, 0, 0, 20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'Gryan Stoutmantle - Random Talk on Completion');
+
+UPDATE `broadcast_text` SET `ChatTypeId`=1 WHERE `Id` IN (197, 199);
+


### PR DESCRIPTION
When turning in the quest [The Defias Brotherhood](https://classic.wowhead.com/quest=166/the-defias-brotherhood), [Gryan Stoutmantle](https://classic.wowhead.com/npc=234/gryan-stoutmantle) will pick one yell out of three random choices.

Also, he does not do a yell emote, or any emote at all.