### PR TITLE
Script end event for The Brokering of Peace

### DIFF
--- a/Updates/3760_the_brokering_of_peace.sql
+++ b/Updates/3760_the_brokering_of_peace.sql
@@ -1,0 +1,10 @@
+UPDATE `quest_template` SET `CompleteScript`=8484 WHERE `entry`=8484;
+UPDATE `quest_template` SET `CompleteScript`=8485 WHERE `entry`=8485;
+
+DELETE FROM `dbscripts_on_quest_end` WHERE `id` IN (8484, 8485);
+INSERT INTO `dbscripts_on_quest_end` (`id`, `delay`, `priority`, `command`, `datalong`, `datalong2`, `datalong3`, `buddy_entry`, `search_radius`, `data_flags`, `dataint`, `dataint2`, `dataint3`, `dataint4`, `x`, `y`, `z`, `o`, `condition_id`, `comments`) VALUES
+(8484, 1000, 0, 0, 0, 0, 0, 0, 0, 0, 11308, 0, 0, 0, 0, 0, 0, 0, 0, 'King Magni Bronzebeard - Yell on Completion'),
+(8485, 1000, 0, 0, 0, 0, 0, 0, 0, 0, 11307, 0, 0, 0, 0, 0, 0, 0, 0, 'Thrall - Yell on Completion');
+
+UPDATE `broadcast_text` SET `ChatTypeID`=1 WHERE `Id` IN (11307, 11308);
+


### PR DESCRIPTION
When you turn in The Brokering of Peace ([Alliance](https://classic.wowhead.com/quest=8484/the-brokering-of-peace), [Horde](https://classic.wowhead.com/quest=8485/the-brokering-of-peace)) the questender (Magni or Thrall) does a yell.

The delay is taken from a similar event (https://github.com/cmangos/classic-db/pull/289) because I could not find a video or sniff of anyone turning this quest in, only [this screenshot](https://classic.wowhead.com/quest=8485/the-brokering-of-peace#comments:id=2729474) without timestamps.

To test:
- .mod rep 576 42999
- .q a 8484 (Alliance) or 8485 (Horde)
- .go creature id 2784 (Magni) or 4949 (Thrall)
- Turn the quest in.

Valid for Vanilla, TBC and WotLK.