### PR TITLE
Add missing quest greetings for NPCs Syral Bladeleaf, Klockmort Spannerspan and Shadowmage Vivian Lagrave

### DIFF
--- a/Updates/3785_questgiver_greetings.sql
+++ b/Updates/3785_questgiver_greetings.sql
@@ -1,0 +1,6 @@
+DELETE FROM `questgiver_greeting` WHERE `Entry` IN (2083, 6169, 9078);
+INSERT INTO `questgiver_greeting` (`Entry`, `Type`, `Text`, `EmoteId`, `EmoteDelay`) VALUES
+(2083, 0, 'Like Teldrassil itself, Dolanaar embraces those who embrace the land.', 0, 0),
+(6169, 0, 'I\'m on quest.  A quest!  A quest for new alloys and harder metals for the greatest invention of all!!', 5, 0),
+(9078, 0, 'Dear $g boy : girl;, you have arrived just in time to assist the Kargath Expeditionary Force.', 1, 0);
+


### PR DESCRIPTION
Confirmed on TBC PTR.