### PR TITLE
Add prev quest requirement for Fool's Stout and make it repeatable

### DIFF
--- a/Updates/3785_fools_stout.sql
+++ b/Updates/3785_fools_stout.sql
@@ -1,0 +1,2 @@
+UPDATE `quest_template` SET `PrevQuestId`=1122, `SpecialFlags`=1 WHERE `entry`=1127;
+


### PR DESCRIPTION
[This quest](https://classic.wowhead.com/quest=1127/fools-stout) is completely useless. Seems to be one of the dead end quests that were planned but not completed. But it is repeatable, and unlocks when [Report Back to Fizzlebub](https://classic.wowhead.com/quest=1122/report-back-to-fizzlebub) is rewarded ([proof](https://classic.wowhead.com/quest=1127/fools-stout#comments:id=2768590)).

Valid for TBC and WotLK too.