### PR TITLE
Fix training gossip option text for Undead Priest trainers

### DIFF
--- a/Updates/3785_undead_priest_trainers.sql
+++ b/Updates/3785_undead_priest_trainers.sql
@@ -1,0 +1,2 @@
+UPDATE `gossip_menu_option` SET `option_text`='I seek more training in the priestly ways.', `option_broadcast_text`=7157 WHERE `menu_id` IN (3645, 4531, 4532, 4533, 4543, 4544, 4545) AND `option_id`=5;
+


### PR DESCRIPTION
Some Undead Priest trainers (like .go creature id 2123) had the wrong default "Train me." option text instead of the correct "I seek more training in the priestly ways.".