### PR TITLE
Fix gossip option text for Priest trainer Ken'jai

### DIFF
--- a/Updates/3785_kenjai.sql
+++ b/Updates/3785_kenjai.sql
@@ -1,0 +1,2 @@
+UPDATE `gossip_menu_option` SET `option_text`='I seek more training in the priestly ways.', `option_broadcast_text`=7157 WHERE `menu_id`=3644 AND `option_id`=5;
+


### PR DESCRIPTION
[Ken'jai](https://classic.wowhead.com/npc=3707/kenjai) had the wrong "Train me." option text instead of the Priest trainer one.