### PR TITLE
Set curmana to 0 in creature table for creatures that are supposed to spawn with full mana (any creature that regenerates mana out of combat)

### DIFF
--- a/Updates/3786_normalize_curmana.sql
+++ b/Updates/3786_normalize_curmana.sql
@@ -1,0 +1,2 @@
+UPDATE `creature` SET `curmana`=0 WHERE `id` IN (SELECT `entry` FROM `creature_template` WHERE `RegenerateStats` & 8 != 0) AND `curmana` != 0;
+


### PR DESCRIPTION
This fix was born out of a need to fix some creatures that had less than maximum mana on spawn and so failed to summon an Imp or Voidwalker (those summon spells take 100% of the NPC's mana), but might as well extend it to any valid creature to avoid other wrong cases.

To test:
Without applying this fix and on Classic only (those creatures have a different script on TBC):
- .go creature 7333
- Enter the cave and walk around. You'll see that level 9 and 10 Apprentices have a Voidwalker, but level 11 ones do not. That's because their levels are randomized and their curmana is lower than the maximum level's max mana.

Valid for Classic and WotLK only, because on TBC curmana is set to 0 in all cases (only some instance spawns from the Instance subfolder still have it, because those are executed after 9999_Final_Misc_Cleanup_Queries.sql). I'm don't have enough data to say that the whole of curmana is useless, so I took the safer approach.