### PR TITLE
issue 2931 fix q.2381 'Plundering the Plunderers' doesn't work

### DIFF
--- a/updates/3897_q_plundering_the_plunderers.sql
+++ b/updates/3897_q_plundering_the_plunderers.sql
@@ -1,0 +1,8 @@
+/* condition_id=1091 is "Quest ID 2381 Taken" */
+UPDATE classicmangos.gossip_menu_option
+SET condition_id=1091
+WHERE menu_id=524 AND id=0; /*Press the yellow button labeled 'Thieves' Tools.'*/
+UPDATE classicmangos.gossip_menu_option
+SET condition_id=1091
+WHERE menu_id=524 AND id=1; /*Press the red button labeled 'E.C.A.C.'*/
+


### PR DESCRIPTION
Fix gossip menu option condition for Plundering the Plunderers Horde rogue quest. Previously, the condition was being exalted with Darnassus.
![plundering](https://user-images.githubusercontent.com/5225386/166240777-bd6bce63-24ab-48b0-8d1d-ff8759c42480.png)

Issue link: https://github.com/cmangos/issues/issues/2931
