### PR TITLE
[4423] Fix q.5156 - Verifying the Corruption

### DIFF
--- a/Updates/4423_q.5156_areatrigger.sql
+++ b/Updates/4423_q.5156_areatrigger.sql
@@ -1,0 +1,7 @@
+-- Makes porting easier
+DELETE FROM `areatrigger_involvedrelation` WHERE `quest` = 5156;
+-- Fixes area trigger for q.5156 'Verifying the Corruption'
+INSERT INTO `areatrigger_involvedrelation` (`id`, `quest`) VALUES
+(2206, 5156),
+(2207, 5156),
+(2208, 5156);


### PR DESCRIPTION
Not sure why this is missing from classic-db as it is present in tbc-db/wotlk-db.
Fixes the area trigger for q.5156 'Verifying the Corruption'. https://www.wowhead.com/classic/quest=5156/verifying-the-corruption