### PR TITLE
4613_Temple_Graveyard_fix

### DIFF
--- a/Updates/4613_Temple_Graveyard_fix.sql
+++ b/Updates/4613_Temple_Graveyard_fix.sql
@@ -1,0 +1,1 @@
+DELETE FROM `game_graveyard_zone` WHERE `id`=309 AND `ghost_loc`=1477 AND `link_kind`=0 AND `faction`=0;


### PR DESCRIPTION
Fixes core crash when a character dies at the Temple of Atal'Hakkar (not the instance) in Swamp of Sorrows.