### PR TITLE
CI: Fix Release-Build Date output

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -231,7 +231,7 @@ jobs:
 
       - name: Get Current Date
         id: date
-        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+        run: echo "date=$(date +'%Y-%m-%d')" >> $env:GITHUB_OUTPUT
 
       - name: Upload Snapshot
         uses: "marvinpinto/action-automatic-releases@latest"


### PR DESCRIPTION
Not urgent. GitHub didn't document that this features works differently on Windows runners. I tested it properly now and on my own repo it works.