### PR TITLE
Fix Druid Aquatic Form quest chain (q.26/27/28/29)

### DIFF
--- a/Updates/4833_q.29_druid_aquatic_form_chain.sql
+++ b/Updates/4833_q.29_druid_aquatic_form_chain.sql
@@ -1,0 +1,19 @@
+-- Fix Druid Aquatic Form quest chain (q.26/27/28/29) - cmangos/issues#4029
+-- The "A Lesson to Learn" -> "Trial of the Lake" links were crossed between the
+-- Alliance (Night Elf) and Horde (Tauren) versions of the chain, so the Aqua form
+-- followup was offered to the wrong race and failed with "That quest is not
+-- available to your race".
+--
+-- Correct chains per Wowhead:
+--   Alliance (RequiredRaces 8):  26 -> 29 -> 272 -> 5061
+--   https://www.wowhead.com/classic/quest=26/a-lesson-to-learn
+--   Horde    (RequiredRaces 32): 27 -> 28 -> 30  -> 31
+--   https://www.wowhead.com/classic/quest=27/a-lesson-to-learn
+
+-- Alliance: A Lesson to Learn (26) -> Trial of the Lake (29)
+UPDATE `quest_template` SET `NextQuestInChain` = 29 WHERE `entry` = 26;
+UPDATE `quest_template` SET `PrevQuestId` = 26 WHERE `entry` = 29;
+
+-- Horde: A Lesson to Learn (27) -> Trial of the Lake (28)
+UPDATE `quest_template` SET `NextQuestInChain` = 28 WHERE `entry` = 27;
+UPDATE `quest_template` SET `PrevQuestId` = 27 WHERE `entry` = 28;


### PR DESCRIPTION
## Problem

A Night Elf druid cannot accept **Trial of the Lake** (quest 29): on `Accept` the client errors with *"That quest is not available to your race"* and the quest is no longer offered.

Reported in cmangos/issues#4029.

## Cause

The `A Lesson to Learn` → `Trial of the Lake` chain links are crossed between the Alliance (Night Elf) and Horde (Tauren) versions. Update `4777_TDB-0638_quest_encrypted_parchment.sql` corrected `RequiredRaces` (26 → Night Elf, 27 → Tauren) but left the chain links pointing at the wrong race's followup, so the Night Elf is offered the Horde quest 28 (`RequiredRaces = 32`).

## Fix

Realign the chain links to match the (now correct) `RequiredRaces`, per Wowhead:

- Alliance (RequiredRaces 8): `26 → 29 → 272 → 5061` — https://www.wowhead.com/classic/quest=26/a-lesson-to-learn
- Horde (RequiredRaces 32): `27 → 28 → 30 → 31` — https://www.wowhead.com/classic/quest=27/a-lesson-to-learn

```sql
UPDATE `quest_template` SET `NextQuestInChain` = 29 WHERE `entry` = 26;
UPDATE `quest_template` SET `PrevQuestId` = 26 WHERE `entry` = 29;
UPDATE `quest_template` SET `NextQuestInChain` = 28 WHERE `entry` = 27;
UPDATE `quest_template` SET `PrevQuestId` = 27 WHERE `entry` = 28;
```

This brings classic-db in line with tbc-db and wotlk-db, whose snapshots already have these chains correct (verified — the bug is classic-only).

## Steps to reproduce (from the issue)

1. Make a level 16 Night Elf druid
2. Pick up class quest *A Lesson to Learn* (26)
3. Finish it by talking to Dendrite Starblaze (11802) in Moonglade
4. Try to accept the followup *Trial of the Lake* (29) — fails with *"That quest is not available to your race"*

Closes cmangos/issues#4029