### PR TITLE
feat(db): Add Battle of Darrowshire (Quest 5721)

### DIFF
--- a/Updates/4833_quest_5721_battle_of_darrowshire.sql
+++ b/Updates/4833_quest_5721_battle_of_darrowshire.sql
@@ -1,0 +1,79 @@
+-- ============================================================================
+-- Battle of Darrowshire — Quest 5721
+-- SQL for CMaNGOS classicmangos database
+-- ============================================================================
+-- v2: all event dialogue now uses RETAIL broadcast_text IDs (verified present
+-- in the base DB). The 28 custom rows (2000001-2000028) are dropped; only the
+-- four Pamela reunion lines (7399-7402, empty in the base DB) are added with
+-- the authentic client texts.
+-- ============================================================================
+
+-- 1. Event Manager NPC (invisible controller)
+-- ============================================================================
+INSERT INTO `creature_template` (
+    `Entry`, `Name`, `SubName`, `MinLevel`, `MaxLevel`,
+    `DisplayId1`, `DisplayId2`, `DisplayId3`, `DisplayId4`,
+    `DisplayIdProbability1`, `DisplayIdProbability2`, `DisplayIdProbability3`, `DisplayIdProbability4`,
+    `Faction`, `Scale`, `Family`, `CreatureType`, `InhabitType`, `RegenerateStats`,
+    `RacialLeader`, `NpcFlags`, `UnitFlags`, `DynamicFlags`, `ExtraFlags`,
+    `CreatureTypeFlags`, `StaticFlags1`, `StaticFlags2`, `StaticFlags3`, `StaticFlags4`,
+    `SpeedWalk`, `SpeedRun`, `Detection`, `CallForHelp`, `Pursuit`, `Leash`, `Timeout`,
+    `UnitClass`, `Rank`,
+    `HealthMultiplier`, `PowerMultiplier`, `DamageMultiplier`, `DamageVariance`, `ArmorMultiplier`,
+    `ExperienceMultiplier`,
+    `StrengthMultiplier`, `AgilityMultiplier`, `StaminaMultiplier`, `IntellectMultiplier`, `SpiritMultiplier`,
+    `MinLevelHealth`, `MaxLevelHealth`, `MinLevelMana`, `MaxLevelMana`,
+    `MinMeleeDmg`, `MaxMeleeDmg`, `MinRangedDmg`, `MaxRangedDmg`,
+    `Armor`, `MeleeAttackPower`, `RangedAttackPower`,
+    `MeleeBaseAttackTime`, `RangedBaseAttackTime`, `DamageSchool`,
+    `MinLootGold`, `MaxLootGold`, `LootId`, `PickpocketLootId`, `SkinningLootId`,
+    `KillCredit1`, `KillCredit2`, `MechanicImmuneMask`, `SchoolImmuneMask`,
+    `ResistanceHoly`, `ResistanceFire`, `ResistanceNature`, `ResistanceFrost`, `ResistanceShadow`, `ResistanceArcane`,
+    `PetSpellDataId`, `MovementType`, `TrainerType`, `TrainerSpell`, `TrainerClass`, `TrainerRace`, `TrainerTemplateId`,
+    `VendorTemplateId`, `GossipMenuId`, `InteractionPauseTimer`, `CorpseDecay`,
+    `SpellList`, `CharmedSpellList`,
+    `StringId1`, `StringId2`, `EquipmentTemplateId`, `Civilian`,
+    `AIName`, `ScriptName`
+) VALUES (
+    18200, 'Darrowshire Event Manager', '', 1, 1,
+    11686, 0, 0, 0,
+    100, 0, 0, 0,
+    35, 1, 0, 10, 3, 0,
+    0, 0, 33555200, 0, 0,
+    0, 0, 0, 0, 0,
+    1, 1.14286, 18, 0, 0, 0, 0,
+    1, 0,
+    1, 1, 1, 1, 1,
+    0.5,
+    1, 1, 1, 1, 1,
+    1, 1, 0, 0,
+    0, 0, 0, 0,
+    0, 0, 0,
+    2000, 2000, 0,
+    0, 0, 0, 0, 0,
+    0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0,
+    0, 0, -1, 0,
+    0, 0,
+    0, 0, 0, 0,
+    '', 'npc_darrowshire_event_manager'
+);
+
+-- 2. GO trigger ScriptName
+-- ============================================================================
+UPDATE `gameobject_template` SET `ScriptName` = 'go_darrowshire_trigger' WHERE `entry` = 177526;
+
+-- 3. Joseph Redpath ScriptName (GossipMenuId 3861 is already set in the base DB)
+-- ============================================================================
+UPDATE `creature_template` SET `ScriptName` = 'npc_joseph_redpath' WHERE `Entry` = 10936;
+
+-- 4. Pamela reunion dialogue — authentic client texts for the rows that are
+--    empty in the base DB (DELETE-first for idempotency, repo convention)
+-- ============================================================================
+DELETE FROM `broadcast_text` WHERE `Id` IN (7399, 7400, 7401, 7402);
+INSERT INTO `broadcast_text` (`Id`, `Text`, `Text1`, `ChatTypeID`, `LanguageID`, `VerifiedBuild`) VALUES
+(7399, 'Daddy!', NULL, 0, 0, 0),
+(7400, 'Daddy! You''re back!', NULL, 0, 0, 0),
+(7401, 'Let''s go play! No, tell me a story, Daddy! No... let''s go pick flowers! And play tea time! I found my dollie, did I tell you?', NULL, 0, 0, 0),
+(7402, 'I missed you so much, Daddy!', NULL, 0, 0, 0);

--- a/Updates/4833_quest_5721_battle_of_darrowshire.sql
+++ b/Updates/4833_quest_5721_battle_of_darrowshire.sql
@@ -10,6 +10,8 @@
 
 -- 1. Event Manager NPC (invisible controller)
 -- ============================================================================
+-- DELETE-first for idempotency (re-running this file must not fail)
+DELETE FROM `creature_template` WHERE `Entry` = 18200;
 INSERT INTO `creature_template` (
     `Entry`, `Name`, `SubName`, `MinLevel`, `MaxLevel`,
     `DisplayId1`, `DisplayId2`, `DisplayId3`, `DisplayId4`,

--- a/Updates/4833_quest_5721_battle_of_darrowshire.sql
+++ b/Updates/4833_quest_5721_battle_of_darrowshire.sql
@@ -2,10 +2,11 @@
 -- Battle of Darrowshire — Quest 5721
 -- SQL for CMaNGOS classicmangos database
 -- ============================================================================
--- v2: all event dialogue now uses RETAIL broadcast_text IDs (verified present
--- in the base DB). The 28 custom rows (2000001-2000028) are dropped; only the
--- four Pamela reunion lines (7399-7402, empty in the base DB) are added with
--- the authentic client texts.
+-- v3: all event dialogue uses RETAIL broadcast_text IDs already present in the
+-- base DB (verified against the z2815 dump: 7227, 7343-7358, 7366-7369,
+-- 7397-7403, 7407, 7471). The Pamela reunion lines (7399-7402) ship in the
+-- base DB with the authentic client texts in Text1, which the core uses for
+-- female speakers, so no broadcast_text rows are touched by this file.
 -- ============================================================================
 
 -- 1. Event Manager NPC (invisible controller)
@@ -69,13 +70,3 @@ UPDATE `gameobject_template` SET `ScriptName` = 'go_darrowshire_trigger' WHERE `
 -- 3. Joseph Redpath ScriptName (GossipMenuId 3861 is already set in the base DB)
 -- ============================================================================
 UPDATE `creature_template` SET `ScriptName` = 'npc_joseph_redpath' WHERE `Entry` = 10936;
-
--- 4. Pamela reunion dialogue — authentic client texts for the rows that are
---    empty in the base DB (DELETE-first for idempotency, repo convention)
--- ============================================================================
-DELETE FROM `broadcast_text` WHERE `Id` IN (7399, 7400, 7401, 7402);
-INSERT INTO `broadcast_text` (`Id`, `Text`, `Text1`, `ChatTypeID`, `LanguageID`, `VerifiedBuild`) VALUES
-(7399, 'Daddy!', NULL, 0, 0, 0),
-(7400, 'Daddy! You''re back!', NULL, 0, 0, 0),
-(7401, 'Let''s go play! No, tell me a story, Daddy! No... let''s go pick flowers! And play tea time! I found my dollie, did I tell you?', NULL, 0, 0, 0),
-(7402, 'I missed you so much, Daddy!', NULL, 0, 0, 0);


### PR DESCRIPTION
# Quest 5721: Battle of Darrowshire (DB support)

Companion DB PR for CMangos/mangos-classic #640.

## What it adds
- **creature_template entry 18200** "Darrowshire Event Manager" (invisible
  event controller) - DELETE-first, so re-running the file never fails
- **ScriptName assignments**: GO 177526 -> `go_darrowshire_trigger`,
  creature 10936 -> `npc_joseph_redpath`
  (GossipMenuId 3861 is already set in the base DB)

## Why so few rows
All event dialogue uses retail broadcast_text IDs already present in the base
DB (7227, 7343-7358, 7366-7369, 7397-7403, 7407, 7471 - verified against the
z2815 dump). The Pamela reunion lines (7399-7402) ship in the base DB with the
authentic client texts in Text1, which the core uses for female speakers, so no
broadcast_text rows are touched by this file.

## Note
Must be merged together with mangos-classic #640: entry 18200 only exists in
this file, so without both PRs the event is a silent no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
