### PR TITLE
Fix swapped PrevQuestId for Trial of the Lake

### DIFF
--- a/Updates/4833_fix_trial_of_the_lake_prevquest.sql
+++ b/Updates/4833_fix_trial_of_the_lake_prevquest.sql
@@ -1,0 +1,3 @@
+-- Fix swapped PrevQuestId for Trial of the Lake (Night Elf vs Tauren)
+UPDATE quest_template SET PrevQuestId = 26 WHERE entry = 29;
+UPDATE quest_template SET PrevQuestId = 27 WHERE entry = 28;


### PR DESCRIPTION
## Issue
Quests 28 and 29 ("Trial of the Lake") had swapped `PrevQuestId` values:
- Quest 29 (Night Elf, RequiredRaces=8) incorrectly required quest 27 (Tauren)
- Quest 28 (Tauren, RequiredRaces=32) incorrectly required quest 26 (Night Elf)

## Fix
- Quest 29 now correctly requires quest 26 (A Lesson to Learn - Night Elf)
- Quest 28 now correctly requires quest 27 (A Lesson to Learn - Tauren)

## Affected quests
- 28 (Trial of the Lake - Tauren)
- 29 (Trial of the Lake - Night Elf)

## Tested
- Night Elf Druid can now accept quest 29 after completing quest 26